### PR TITLE
fix: change precedence for default flex property

### DIFF
--- a/lib/src/v2/_grid.scss
+++ b/lib/src/v2/_grid.scss
@@ -119,19 +119,19 @@
 }
 
 @for $i from 1 through $cols {
+  [#{$scope-prefix}layout*='#{$i}\@'] {
+    -webkit-flex: 0 0 auto;
+    -ms-flex: 0 0 auto;
+    flex: 0 0 auto;
+  }
+}
+
+@for $i from 1 through $cols {
   [#{$scope-prefix}layout~='#{$i}'] {
     max-width: percentage($i/$cols);
     -ms-flex-preferred-size: percentage($i/$cols);
     -webkit-flex-basis: percentage($i/$cols);
     flex-basis: percentage($i/$cols);
-  }
-}
-
-@for $i from 1 through $cols {
-  [#{$scope-prefix}layout*='#{$i}\@'] {
-    -webkit-flex: 0 0 auto;
-    -ms-flex: 0 0 auto;
-    flex: 0 0 auto;
   }
 }
 


### PR DESCRIPTION
This change fixes a bug in older versions of Safari where the styles for responsive columns were not always applied. This was due to an incorrect precedence of the default flex property for columns: the flex-basis styles needed to cascade the default flex styles.