### PR TITLE
Allow custom config

### DIFF
--- a/lib/src/_config.scss
+++ b/lib/src/_config.scss
@@ -1,37 +1,37 @@
 // Prefixes
-$prefix: 'bp'; // prefix layout attibute
+$prefix: 'bp' !default; // prefix layout attibute
 
 // Grid Variables
-$container-width: 1000px;
-$gutter: 16px;
-$cols: 12;
+$container-width: 1000px !default;
+$gutter: 16px !default;
+$cols: 12 !default;
 
 // Breakpoint Variables
-$no-break: 0;
-$sm-break: 480px;
-$md-break: 720px;
-$lg-break: 960px;
-$xl-break: 1440px;
+$no-break: 0 !default;
+$sm-break: 480px !default;
+$md-break: 720px !default;
+$lg-break: 960px !default;
+$xl-break: 1440px !default;
 
 // Spacing Variables
-$xs-spacing: 4px;
-$sm-spacing: 8px;
-$md-spacing: 16px;
-$lg-spacing: 24px;
+$xs-spacing: 4px !default;
+$sm-spacing: 8px !default;
+$md-spacing: 16px !default;
+$lg-spacing: 24px !default;
 
 // Size Suffixes
-$xs-suffix: '--xs';
-$sm-suffix: '--sm';
-$md-suffix: '';
-$lg-suffix: '--lg';
-$none-suffix: '--none';
+$xs-suffix: '--xs' !default;
+$sm-suffix: '--sm' !default;
+$md-suffix: '' !default;
+$lg-suffix: '--lg' !default;
+$none-suffix: '--none' !default;
 
 // Location Suffixes
-$no-suffix: '';
-$top-suffix: '-top';
-$bottom-suffix: '-bottom';
-$left-suffix: '-left';
-$right-suffix: '-right';
+$no-suffix: '' !default;
+$top-suffix: '-top' !default;
+$bottom-suffix: '-bottom' !default;
+$left-suffix: '-left' !default;
+$right-suffix: '-right' !default;
 
 // Lists
 $location-suffixes: $no-suffix, $top-suffix, $bottom-suffix, $right-suffix, $left-suffix;


### PR DESCRIPTION
By adding a simple `!default` to the config variables, they can easily be overwritten if the user wants to build the css themselves. This PR adds this feature.