### PR TITLE
fix: release layout and theme fixes

### DIFF
--- a/packages/components/package.lib.json
+++ b/packages/components/package.lib.json
@@ -40,13 +40,13 @@
   },
   "dependencies": {
     "@blueprintui/icons": "^0.0.21",
-    "@blueprintui/themes": "^0.0.12",
+    "@blueprintui/themes": "^0.0.13",
     "@floating-ui/dom": "^1.0.7",
     "lit": "^2.5.0",
     "tslib": "^2.4.1"
   },
   "optionalDependencies": {
-    "@blueprintui/layout": "^0.0.8",
+    "@blueprintui/layout": "^0.0.9",
     "@blueprintui/typography": "^0.0.15",
     "modern-normalize": "^1.1.0"
   }

--- a/packages/components/src/button/element.css
+++ b/packages/components/src/button/element.css
@@ -89,7 +89,7 @@
 }
 
 :host([action='outline'][disabled]) {
-  --color: var(--bp-status-disabled-background-200);
+  --color: var(--bp-status-disabled-background-100);
   --cursor: default;
 }
 

--- a/packages/icons/package.lib.json
+++ b/packages/icons/package.lib.json
@@ -41,6 +41,6 @@
     "lit": "^2.5.0"
   },
   "optionalDependencies": {
-    "@blueprintui/themes": "^0.0.12"
+    "@blueprintui/themes": "^0.0.13"
   }
 }

--- a/packages/layout/CHANGELOG.md
+++ b/packages/layout/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.9
+- fix: prevent grid overflow when using gaps that exceed viewport width
+
 ## 0.0.8
 - minor alignment fixes
 - dependencies update

--- a/packages/layout/package.lib.json
+++ b/packages/layout/package.lib.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintui/layout",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "index.css",
   "type":"module",
   "license": "MIT",
@@ -15,7 +15,7 @@
     "url": "https://github.com/blueprintui/blueprintui/issues"
   },
   "optionalDependencies": {
-    "@blueprintui/themes": "^0.0.12",
+    "@blueprintui/themes": "^0.0.13",
     "modern-normalize": "^1.1.0"
   }
 }

--- a/packages/layout/src/_mixins.scss
+++ b/packages/layout/src/_mixins.scss
@@ -37,7 +37,7 @@ $bp-layout-spacing-sides: (
 @mixin generateGaps($breakpoint: null) {
   @each $size, $sizeValue in $bp-layout-sizes {
     [#{$layout}~='#{$gap}:#{$size}#{$breakpoint}'] {
-      gap: $sizeValue;
+      gap: min($bp-gap-fr, $sizeValue);
     }
   }
 }

--- a/packages/layout/src/_tokens.scss
+++ b/packages/layout/src/_tokens.scss
@@ -52,6 +52,7 @@ $bp-space-sm: var(--β2);
 $bp-space-md: var(--β3);
 $bp-space-lg: var(--β4);
 $bp-space-xl: var(--β5);
+$bp-gap-fr: var(--βgfr);
 
 :root,
 :host {
@@ -60,4 +61,5 @@ $bp-space-xl: var(--β5);
   --β3: var(--bp-space-md, 24px);
   --β4: var(--bp-space-lg, 48px);
   --β5: var(--bp-space-xl, 64px);
+  --βgfr: calc(100vw / 12);
 }

--- a/packages/themes/CHANGELOG.md
+++ b/packages/themes/CHANGELOG.md
@@ -1,18 +1,22 @@
 # Changelog
+ 
+## 0.0.13
+- fix: modern-dark disabled background contrast
+- feat: added `--bp-scale-interaction-offset` to easily scale interaction layers across themes
 
 ## 0.0.11 (breaking)
-- implement field range for layering
-- add modern light/dark themes
-- default to system themes
+- feat: implement field range for layering
+- feat: add modern light/dark themes
+- feat: default to system themes
 
 ## 0.0.10 (breaking)
-- implement system light/dark as default themes
-- implement modern light/default themes
-- adjust interaction tokens for hsla support
+- feat: implement system light/dark as default themes
+- feat: implement modern light/default themes
+- fix: adjust interaction tokens for hsla support
 
 ## 0.0.9
-- minor adjustment for better type scale colors
+- fix: minor adjustment for better type scale colors
 
 ## 0.0.7
-- merge themes/tokens repos into single theme repo
-- align token build between all themes
+- chore: merge themes/tokens repos into single theme repo
+- chore: align token build between all themes

--- a/packages/themes/package.lib.json
+++ b/packages/themes/package.lib.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintui/themes",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "index.js",
   "license": "MIT",
   "author": "Crylan Software",

--- a/packages/themes/src/index.json
+++ b/packages/themes/src/index.json
@@ -3,7 +3,8 @@
   "scale": {
     "size": { "value": "1" },
     "space": { "value": "1" },
-    "text": { "value": "1" }
+    "text": { "value": "1" },
+    "interaction-offset": { "value": "1" }
   },
   "space": {
     "xs": { "value": "calc({scale.space} * 8px)" },
@@ -263,27 +264,27 @@
       "background" : { "value": "{color.blue.600}" }
     },
     "default": {
-      "offset": { "value": "0" },
+      "offset": { "value": "calc({scale.interaction-offset} * 0)" },
       "color": { "value": "ButtonText" }
     },
     "hover": {
-      "offset":{ "value": "0.1" },
+      "offset":{ "value": "calc({scale.interaction-offset} * 0.1)" },
       "color": { "value": "ButtonText" }
     },
     "focused": {
-      "offset": { "value": "0.1" },
+      "offset": { "value": "calc({scale.interaction-offset} * 0.1)" },
       "color": { "value": "ButtonText" }
     },
     "active": {
-      "offset": { "value": "0.15" },
+      "offset": { "value": "calc({scale.interaction-offset} * 0.15)" },
       "color": { "value": "ActiveText" }
     },
     "selected": { 
-      "offset": { "value": "0.09" },
+      "offset": { "value": "calc({scale.interaction-offset} * 0.09)" },
       "color": { "value": "ButtonText" }
     },
     "disabled": {
-      "offset": { "value": "0" },
+      "offset": { "value": "calc({scale.interaction-offset} * 0)" },
       "color": { "value": "GrayText" }
     }
   }

--- a/packages/themes/src/index.performance.js
+++ b/packages/themes/src/index.performance.js
@@ -1,8 +1,8 @@
 import { testBundleSize } from 'web-test-runner-performance/browser.js';
 
 describe('performance', () => {
-  it('should keep default theme tokens under 1.2kb', async () => {
-    expect((await testBundleSize(`import '@blueprintui/themes/index.min.css'`, { optimize: true })).kb).toBeLessThan(1.2);
+  it('should keep default theme tokens under 1.25kb', async () => {
+    expect((await testBundleSize(`import '@blueprintui/themes/index.min.css'`, { optimize: true })).kb).toBeLessThan(1.25);
   });
 
   it('should keep dark theme tokens under 0.4kb', async () => {

--- a/packages/themes/src/modern-dark.theme.json
+++ b/packages/themes/src/modern-dark.theme.json
@@ -1,5 +1,8 @@
 {
   "color-scheme": { "value": "dark" },
+  "scale": {
+    "interaction-offset": { "value": "1" }
+  },
   "text": {
     "color": {
       "100": { "value": "{color.white}" },
@@ -97,8 +100,8 @@
     "disabled": {
       "background": {
         "100": { "value": "{color.gray.500}" },
-        "200": { "value": "{color.gray.700}" },
-        "300": { "value": "{color.gray.700}" }
+        "200": { "value": "{color.gray.600}" },
+        "300": { "value": "{color.gray.600}" }
       },
       "color": {
         "100": { "value": "{text.color.600}" }

--- a/packages/themes/src/modern.theme.json
+++ b/packages/themes/src/modern.theme.json
@@ -1,5 +1,8 @@
 {
   "color-scheme": { "value": "normal" },
+  "scale": {
+    "interaction-offset": { "value": "0.5" }
+  },
   "color": {
     "black": { "value": "hsl(0, 0%, 0%)" },
     "white": { "value": "hsl(0, 0%, 100%)" },
@@ -183,7 +186,7 @@
   },
   "interaction": {
     "highlight": {
-      "background" : { "value": "hsla(211, 100%, 75%, 0.15)" }
+      "background" : { "value": "hsla(240, 100%, 75%, 0.15)" }
     },
     "accent": {
       "background" : { "value": "{status.accent.background.200}" }

--- a/packages/typography/package.lib.json
+++ b/packages/typography/package.lib.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/blueprintui/blueprintui/issues"
   },
   "optionalDependencies": {
-    "@blueprintui/themes": "^0.0.12",
+    "@blueprintui/themes": "^0.0.13",
     "modern-normalize": "^1.1.0"
   }
 }


### PR DESCRIPTION
- fix: prevent grid overflow when using gaps that exceed viewport width
- fix: modern-dark disabled background contrast
- feat: added `--bp-scale-interaction-offset` to scale across themes
