### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -27,7 +27,7 @@ module.exports = {
       }
     ],
     [
-      '@google/semantic-release-replace-plugin',
+      'semantic-release-replace-plugin',
       {
         replacements: [
           {

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "@blueprintui/drafter": "0.8.4",
     "@commitlint/cli": "17.6.1",
     "@commitlint/config-conventional": "17.6.1",
-    "@google/semantic-release-replace-plugin": "1.2.0",
+    "semantic-release-replace-plugin": "1.2.0",
     "@playwright/test": "1.33.0",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/commit-analyzer": "9.0.2",


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).