### PR TITLE
fix(components): fix firefox styles and radio associations

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["chrome-devtools-mcp@latest"]
+    }
+  }
+}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
       - uses: actions/stale@v7
         with:
-          days-before-stale: 90
+          days-before-stale: 60
           stale-pr-label: 'flag:stale'
           stale-issue-label: 'flag:stale'
-          days-before-close: 365
+          days-before-close: 180
           stale-issue-message: 'Hello there 👋. This is an automated message to let you know that in order to keep the repository running smoothly, we automatically close issues and pull requests that have not been active for a while. If you would like to continue discussing this topic, please look for another open issue or create a new one with updated information, and include a reference to this issue as needed.'
           stale-pr-message: 'Hello there 👋. This is an automated message to let you know that in order to keep the repository running smoothly, we automatically close issues and pull requests that have not been active for a while. If you would like to continue discussing this topic, please look for another open issue or create a new one with updated information, and include a reference to this issue as needed.'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Crylan Software",
   "license": "",
   "type": "module",
-  "packageManager": "pnpm@10.18.0",
+  "packageManager": "pnpm@10.18.2",
   "engines": {
     "node": "22.19.0"
   },

--- a/projects/components/src/internals/utils/a11y.ts
+++ b/projects/components/src/internals/utils/a11y.ts
@@ -45,5 +45,5 @@ export function associateAriaLabel(label: HTMLElement, element: HTMLElement) {
 
 export function associateFieldNames(inputs: HTMLInputElement[]) {
   const name = createId();
-  inputs.filter(i => !i.name && !i.getAttribute('name')).forEach(i => (i.name = name));
+  inputs.filter(i => !i.name && !i.getAttribute('name')).forEach(i => i.setAttribute('name', name));
 }

--- a/projects/components/src/select/element.css
+++ b/projects/components/src/select/element.css
@@ -36,6 +36,7 @@
 }
 
 select {
+  -moz-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
   appearance: base-select; /* stylelint-disable-line declaration-property-value-no-unknown */
   background: var(--background);
   border-radius: var(--border-radius);

--- a/projects/components/src/toast/element.css
+++ b/projects/components/src/toast/element.css
@@ -4,10 +4,10 @@
   --filter: drop-shadow(var(--bp-object-shadow-200));
   --background: var(--bp-layer-background-200);
   --color: var(--bp-text-color-500);
-  --width: max-content;
-  --height: max-content;
+  --width: fit-content;
+  --height: fit-content;
   --min-width: 250px;
-  --min-height: max-content;
+  --min-height: fit-content;
   --font-size: var(--bp-text-size-200);
   --border-left: var(--bp-object-border-width-300) solid var(--status-color);
   --border-radius: var(--bp-object-border-radius-100);


### PR DESCRIPTION
- Enhanced a11y tests to ensure name attributes are set correctly on input elements.
- Updated fieldset tests to validate behavior with bp-radio elements.
- Adjusted CSS for select and toast components for improved styling consistency.

closes #328
closes #329