### PR TITLE
fix(docs): correct css token naming in documentation

### DIFF
--- a/projects/docs/src/_examples/tokens.examples.js
+++ b/projects/docs/src/_examples/tokens.examples.js
@@ -2,14 +2,22 @@ import json from '@blueprintui/themes/index.json' with { type: 'json' };
 
 const tokens = flattenTokens(json);
 
+function camelCaseToKebabCase(str) {
+  return str
+    .replace(/([A-Z])/g, '-$1')
+    .toLowerCase()
+    .replace(/([a-z])(\d)/g, '$1-$2');
+}
+
 function flattenTokens(theme) {
   function flatten(config, parent = '--bp') {
     return Object.entries(config).map(([key, value]) => {
+        const kebabKey = camelCaseToKebabCase(key);
         if (typeof value === 'object') {
-          return flatten(value, `${parent}-${key}`);
+          return flatten(value, `${parent}-${kebabKey}`);
         }
 
-        return { [`${parent}-${key}`]: value };
+        return { [`${parent}-${kebabKey}`]: value };
       })
       .reduce((prev, next) => ({ ...prev, ...next }), {});
   }


### PR DESCRIPTION
the documentation was displaying CSS tokens in camelCase format instead of the correct kebab-case format used by the actual CSS.

- added camelCaseToKebabCase helper function to convert JSON keys properly
- updated flattenTokens function to use kebab-case conversion
- ensures documentation tokens match the actual CSS variable names

🤖 Generated with [Claude Code](https://claude.com/claude-code)