### PR TITLE
feat(components): add token-segment component for llm tokenization vi…

### DIFF
--- a/projects/components/screenshots/Chromium/baseline/format-token/dark.png
+++ b/projects/components/screenshots/Chromium/baseline/format-token/dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25799c44a1abd3ea7d50774ee294b09a76d825aba5d37f86bf03fcfec65b0cbd
+size 8058

--- a/projects/components/screenshots/Chromium/baseline/format-token/light.png
+++ b/projects/components/screenshots/Chromium/baseline/format-token/light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95b630f2562a8de03322840dcfadd8be41cb70cfad46b747536bc2fcf7314a5e
+size 8074

--- a/projects/components/src/format-token/element.css
+++ b/projects/components/src/format-token/element.css
@@ -1,0 +1,27 @@
+:host {
+  --gap: var(--bp-size-300);
+  --border-radius: var(--bp-object-border-radius-100);
+  --border: var(--bp-object-border-width-100) solid rgb(0, 0, 0, 10%);
+  --font-family: var(--bp-text-monospace-family);
+  --color: var(--bp-color-black);
+  --padding: var(--bp-size-300);
+  --line-height: 16px;
+  display: block;
+}
+
+[part='internal'] {
+  color: var(--color);
+  gap: var(--gap);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+[part='token'] {
+  line-height: var(--line-height);
+  border-radius: var(--border-radius);
+  padding: var(--padding);
+  border: var(--border);
+  display: inline-block;
+  text-box: trim-both cap alphabetic;
+}

--- a/projects/components/src/format-token/element.examples.js
+++ b/projects/components/src/format-token/element.examples.js
@@ -1,0 +1,91 @@
+export const metadata = {
+  name: 'format-token',
+  elements: ['bp-format-token']
+};
+
+export function example() {
+  return /* html */ `
+    <script type="module">
+      import '@blueprintui/components/include/format-token.js';
+    </script>
+
+    <bp-format-token>Hello world! This is a test of token segmentation.</bp-format-token>
+  `;
+}
+
+export function formats() {
+  return /* html */ `
+    <script type="module">
+      import '@blueprintui/components/include/format-token.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <div>
+        <h4>BPE (GPT-style)</h4>
+        <bp-format-token format="bpe">Hello world! This is a test.</bp-format-token>
+      </div>
+
+      <div>
+        <h4>WordPiece (BERT-style)</h4>
+        <bp-format-token format="word-piece">Hello world! This is a test.</bp-format-token>
+      </div>
+
+      <div>
+        <h4>SentencePiece</h4>
+        <bp-format-token format="sentence-piece">Hello world! This is a test.</bp-format-token>
+      </div>
+
+      <div>
+        <h4>LLaMA</h4>
+        <bp-format-token format="llama">Hello world! This is a test.</bp-format-token>
+      </div>
+
+      <div>
+        <h4>Character-level</h4>
+        <bp-format-token format="character">Hello world!</bp-format-token>
+      </div>
+
+      <div>
+        <h4>Whitespace</h4>
+        <bp-format-token format="whitespace">Hello world! This is a test.</bp-format-token>
+      </div>
+    </div>
+  `;
+}
+
+export function technicalText() {
+  return /* html */ `
+    <script type="module">
+      import '@blueprintui/components/include/format-token.js';
+    </script>
+
+    <bp-format-token format="word-piece">
+      function calculateTotal(items) { return items.reduce((sum, item) => sum + item.price, 0); }
+    </bp-format-token>
+  `;
+}
+
+export function multilingualText() {
+  return /* html */ `
+    <script type="module">
+      import '@blueprintui/components/include/format-token.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <div>
+        <h4>English</h4>
+        <bp-format-token format="sentence-piece">Hello, how are you?</bp-format-token>
+      </div>
+
+      <div>
+        <h4>Numbers and Symbols</h4>
+        <bp-format-token format="llama">Price: $1,234.56 (25% off)</bp-format-token>
+      </div>
+
+      <div>
+        <h4>Mixed Content</h4>
+        <bp-format-token format="bpe">Visit https://example.com for more info!</bp-format-token>
+      </div>
+    </div>
+  `;
+}

--- a/projects/components/src/format-token/element.performance.ts
+++ b/projects/components/src/format-token/element.performance.ts
@@ -1,0 +1,16 @@
+import { testBundleSize, testRenderTime, html } from 'web-test-runner-performance/browser.js';
+import '@blueprintui/components/include/format-token.js';
+
+describe('bp-format-token performance', () => {
+  const element = html`<bp-format-token>hello world</bp-format-token>`;
+
+  it(`should bundle and treeshake under 8kb`, async () => {
+    expect(
+      (await testBundleSize('@blueprintui/components/include/format-token.js', { optimize: true })).kb
+    ).toBeLessThan(8);
+  });
+
+  it(`should render under 30ms`, async () => {
+    expect((await testRenderTime(element)).duration).toBeLessThan(30);
+  });
+});

--- a/projects/components/src/format-token/element.spec.ts
+++ b/projects/components/src/format-token/element.spec.ts
@@ -1,0 +1,201 @@
+import { html } from 'lit';
+import '@blueprintui/components/include/format-token.js';
+import { BpFormatToken } from '@blueprintui/components/format-token';
+import { elementIsStable, createFixture, removeFixture } from '@blueprintui/test';
+
+describe('bp-format-token', () => {
+  let fixture: HTMLElement;
+  let element: BpFormatToken;
+
+  beforeEach(async () => {
+    fixture = await createFixture(html`<bp-format-token>Hello world!</bp-format-token>`);
+    element = fixture.querySelector<BpFormatToken>('bp-format-token');
+    await elementIsStable(element);
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('should register element', async () => {
+    await elementIsStable(element);
+    expect(customElements.get('bp-format-token')).toBe(BpFormatToken);
+  });
+
+  it('should default to bpe format', async () => {
+    await elementIsStable(element);
+    expect(element.format).toBe('bpe');
+    expect(element.getAttribute('format')).toBe('bpe');
+  });
+
+  it('should handle format property changes', async () => {
+    await elementIsStable(element);
+    element.format = 'bpe';
+    await elementIsStable(element);
+
+    expect(element.format).toBe('bpe');
+    expect(element.getAttribute('format')).toBe('bpe');
+  });
+
+  it('should tokenize text with word-piece format', async () => {
+    element.textContent = 'Hello world!';
+    element.format = 'word-piece';
+    await elementIsStable(element);
+
+    const tokens = element.shadowRoot?.querySelectorAll('[part="token"]');
+    expect(tokens.length).toBeGreaterThan(0);
+  });
+
+  it('should support different tokenization formats', async () => {
+    const formats = ['word-piece', 'bpe', 'sentence-piece', 'llama', 'character', 'whitespace'] as const;
+
+    for (const format of formats) {
+      element.format = format;
+      await elementIsStable(element);
+      expect(element.getAttribute('format')).toBe(format);
+    }
+  });
+
+  it('should handle empty text', async () => {
+    element.textContent = '';
+    await elementIsStable(element);
+
+    const placeholder = element.shadowRoot?.querySelector('[part="placeholder"]');
+    expect(placeholder).toBeTruthy();
+  });
+
+  it('should handle text content changes', async () => {
+    await elementIsStable(element);
+    element.textContent = 'New text content';
+    element.dispatchEvent(new Event('bp-textchange'));
+    await elementIsStable(element);
+
+    expect(element.textContent).toBe('New text content');
+  });
+
+  it('should have internal part element', async () => {
+    await elementIsStable(element);
+    const internal = element.shadowRoot?.querySelector('[part="internal"]');
+    expect(internal).toBeTruthy();
+    expect(internal?.tagName).toBe('DIV');
+  });
+
+  it('should tokenize with character format', async () => {
+    element.textContent = 'Hi';
+    element.format = 'character';
+    await elementIsStable(element);
+
+    const tokens = element.shadowRoot?.querySelectorAll('[part="token"]');
+    expect(tokens.length).toBe(2); // 'H' and 'i'
+  });
+
+  it('should tokenize with whitespace format', async () => {
+    element.textContent = 'Hello world test';
+    element.format = 'whitespace';
+    await elementIsStable(element);
+
+    const tokens = element.shadowRoot?.querySelectorAll('[part="token"]');
+    expect(tokens.length).toBe(3); // 'Hello', 'world', 'test'
+  });
+
+  it('should return tokens', async () => {
+    element.textContent = 'Hello world';
+    element.format = 'word-piece';
+    await elementIsStable(element);
+    expect(element.tokens.length).toBe(3);
+    expect(element.tokens[0]).toBe('Hello');
+  });
+
+  it('should apply token colors', async () => {
+    element.textContent = 'Test tokenization';
+    await elementIsStable(element);
+
+    const firstToken = element.shadowRoot?.querySelector('[part="token"]') as HTMLElement;
+    expect(firstToken).toBeTruthy();
+    expect(firstToken.style.backgroundColor).toBeTruthy();
+  });
+
+  it('should allow CSS custom properties to be overridden', async () => {
+    element.style.setProperty('--background', 'red');
+    element.style.setProperty('--padding', '20px');
+    element.style.setProperty('--border-radius', '10px');
+    element.style.setProperty('--font-family', 'monospace');
+
+    await elementIsStable(element);
+
+    expect(element.style.getPropertyValue('--background')).toBe('red');
+    expect(element.style.getPropertyValue('--padding')).toBe('20px');
+    expect(element.style.getPropertyValue('--border-radius')).toBe('10px');
+    expect(element.style.getPropertyValue('--font-family')).toBe('monospace');
+  });
+
+  it('should update tokens when format changes', async () => {
+    element.textContent = 'Testing';
+    element.format = 'word-piece';
+    await elementIsStable(element);
+
+    const tokensWordPiece = element.shadowRoot?.querySelectorAll('[part="token"]').length;
+
+    element.format = 'character';
+    await elementIsStable(element);
+
+    const tokensCharacter = element.shadowRoot?.querySelectorAll('[part="token"]').length;
+
+    expect(tokensCharacter).toBeGreaterThan(tokensWordPiece || 0);
+  });
+
+  it('should render slot for placeholder content', async () => {
+    const fixtureWithSlot = await createFixture(html`<bp-format-token></bp-format-token>`);
+    const elementWithSlot = fixtureWithSlot.querySelector<BpFormatToken>('bp-format-token');
+    await elementIsStable(elementWithSlot);
+
+    const slot = elementWithSlot.shadowRoot?.querySelector('slot');
+    expect(slot).toBeTruthy();
+
+    removeFixture(fixtureWithSlot);
+  });
+
+  it('should handle special characters in tokenization', async () => {
+    element.textContent = 'Hello, world! 123';
+    element.format = 'word-piece';
+    await elementIsStable(element);
+
+    const tokens = element.shadowRoot?.querySelectorAll('[part="token"]');
+    expect(tokens.length).toBeGreaterThan(0);
+  });
+
+  it('should handle sentence-piece format with space markers', async () => {
+    element.textContent = 'Hello world';
+    element.format = 'sentence-piece';
+    await elementIsStable(element);
+
+    const tokens = element.shadowRoot?.querySelectorAll('[part="token"]');
+    expect(tokens.length).toBeGreaterThan(0);
+
+    // Check for space marker (▁)
+    const hasSpaceMarker = Array.from(tokens).some(token => token.textContent?.includes('▁'));
+    expect(hasSpaceMarker).toBe(true);
+  });
+
+  it('should handle llama format with space markers', async () => {
+    element.textContent = 'Testing LLaMA';
+    element.format = 'llama';
+    await elementIsStable(element);
+
+    const tokens = element.shadowRoot?.querySelectorAll('[part="token"]');
+    expect(tokens.length).toBeGreaterThan(0);
+
+    // Check for space marker (▁)
+    const hasSpaceMarker = Array.from(tokens).some(token => token.textContent?.includes('▁'));
+    expect(hasSpaceMarker).toBe(true);
+  });
+
+  it('should handle bpe format', async () => {
+    element.textContent = 'Testing BPE tokenization';
+    element.format = 'bpe';
+    await elementIsStable(element);
+
+    const tokens = element.shadowRoot?.querySelectorAll('[part="token"]');
+    expect(tokens.length).toBeGreaterThan(0);
+  });
+});

--- a/projects/components/src/format-token/element.ts
+++ b/projects/components/src/format-token/element.ts
@@ -1,0 +1,346 @@
+import { html, LitElement, PropertyValues } from 'lit';
+import { property } from 'lit/decorators/property.js';
+import { state } from 'lit/decorators/state.js';
+import { baseStyles, interactionTextChange } from '@blueprintui/components/internals';
+import styles from './element.css' with { type: 'css' };
+
+/**
+ * ```typescript
+ * import '@blueprintui/components/include/format-token.js';
+ * ```
+ *
+ * ```html
+ * <bp-format-token format="word-piece">Hello world!</bp-format-token>
+ * ```
+ *
+ * @summary The format token component visualizes text tokenization for language models, displaying how text is split into tokens using various tokenization strategies like WordPiece, BPE, SentencePiece, and LLaMA.
+ * @element bp-format-token
+ * @since 2.8.0
+ * @slot - Provide text content to be tokenized
+ * @cssprop --padding
+ * @cssprop --border-radius
+ * @cssprop --border
+ * @cssprop --font-family
+ * @cssprop --line-height
+ * @cssprop --gap
+ */
+@interactionTextChange()
+export class BpFormatToken extends LitElement {
+  static styles = [baseStyles, styles];
+
+  /** Tokenization format/strategy to use */
+  @property({ type: String, reflect: true }) accessor format:
+    | 'bpe'
+    | 'word-piece'
+    | 'sentence-piece'
+    | 'llama'
+    | 'character'
+    | 'whitespace' = 'bpe';
+
+  @state() private accessor _text = '';
+
+  get tokens(): string[] {
+    return this.#tokens;
+  }
+
+  #tokens: string[] = [];
+
+  #colors = [
+    'var(--bp-color-red-100)',
+    'var(--bp-color-blue-100)',
+    'var(--bp-color-green-100)',
+    'var(--bp-color-yellow-100)',
+    'var(--bp-color-violet-100)'
+  ];
+
+  render() {
+    if (!this.#tokens.length) {
+      return html`
+        <div part="internal">
+          <div part="placeholder">
+            <slot></slot>
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div part="internal">
+        ${this.#tokens.map(
+          (token, index) => html`
+            <span part="token" style="background-color: ${this.#colors[index % this.#colors.length]}"> ${token} </span>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  updated(props: PropertyValues<this>) {
+    super.updated(props);
+
+    if (props.has('format')) {
+      this.#updateTokens();
+    }
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._text = this.textContent?.trim() ?? '';
+    this.#updateTokens();
+    this.addEventListener('bp-textchange', () => {
+      this._text = this.textContent?.trim() ?? '';
+      this.#updateTokens();
+    });
+  }
+
+  #updateTokens() {
+    const text = this._text ?? '';
+    this.#tokens = this.#tokenize(text);
+    this.requestUpdate();
+  }
+
+  #tokenize(text: string): string[] {
+    if (!text || text.trim() === '') return [];
+
+    switch (this.format) {
+      case 'sentence-piece':
+        return this.#tokenizeSentencePiece(text);
+      case 'bpe':
+        return this.#tokenizeBPE(text);
+      case 'llama':
+        return this.#tokenizeLLaMA(text);
+      case 'character':
+        return this.#tokenizeCharacter(text);
+      case 'whitespace':
+        return this.#tokenizeWhitespace(text);
+      default:
+        return this.#tokenizeWordPiece(text);
+    }
+  }
+
+  #tokenizeWordPiece(text: string): string[] {
+    const tokens: string[] = [];
+    let i = 0;
+
+    while (i < text.length) {
+      let token = '';
+
+      // Handle whitespace - WordPiece treats spaces as separate tokens
+      if (/\s/.test(text[i])) {
+        while (i < text.length && /\s/.test(text[i])) {
+          token += text[i];
+          i++;
+        }
+        tokens.push(token);
+        continue;
+      }
+
+      // Handle punctuation
+      if (/[^\w\s]/.test(text[i])) {
+        token = text[i];
+        i++;
+        tokens.push(token);
+        continue;
+      }
+
+      // Handle words/subwords
+      if (/\w/.test(text[i])) {
+        while (i < text.length && /\w/.test(text[i])) {
+          token += text[i];
+          i++;
+        }
+
+        if (token.length > 6) {
+          const subTokens = this.#splitIntoSubwords(token, 'word-piece');
+          tokens.push(...subTokens);
+        } else {
+          tokens.push(token);
+        }
+        continue;
+      }
+
+      // Fallback
+      token = text[i];
+      i++;
+      tokens.push(token);
+    }
+
+    return tokens;
+  }
+
+  #tokenizeLLaMA(text: string): string[] {
+    const tokens: string[] = [];
+    let i = 0;
+
+    while (i < text.length) {
+      // Handle whitespace - mark next non-space token with ▁
+      if (/\s/.test(text[i])) {
+        while (i < text.length && /\s/.test(text[i])) {
+          i++;
+        }
+        // Mark the next token with ▁ (space boundary)
+        if (i < text.length) {
+          let token = this.#extractNextToken(text, i);
+          if (token.length > 5) {
+            const subTokens = this.#splitIntoSubwords(token, 'llama');
+            if (subTokens.length > 0) {
+              subTokens[0] = '▁' + subTokens[0];
+              tokens.push(...subTokens);
+            }
+          } else {
+            tokens.push('▁' + token);
+          }
+          i += token.length;
+        }
+        continue;
+      }
+
+      // Handle numbers
+      if (/\d/.test(text[i])) {
+        let token = '';
+        while (i < text.length && /\d/.test(text[i])) {
+          token += text[i];
+          i++;
+        }
+        if (tokens.length === 0 || this.#isAfterSpace(text, i - token.length)) {
+          token = '▁' + token;
+        }
+        tokens.push(token);
+        continue;
+      }
+
+      // Handle punctuation
+      if (/[^\w\s]/.test(text[i])) {
+        let token = text[i];
+        if (tokens.length === 0 || this.#isAfterSpace(text, i)) {
+          token = '▁' + token;
+        }
+        tokens.push(token);
+        i++;
+        continue;
+      }
+
+      // Handle regular words
+      if (/\w/.test(text[i])) {
+        let token = this.#extractNextToken(text, i);
+
+        if (token.length > 5) {
+          const subTokens = this.#splitIntoSubwords(token, 'llama');
+          if (tokens.length === 0 || this.#isAfterSpace(text, i)) {
+            subTokens[0] = '▁' + subTokens[0];
+          }
+          tokens.push(...subTokens);
+        } else {
+          if (tokens.length === 0 || this.#isAfterSpace(text, i)) {
+            token = '▁' + token;
+          }
+          tokens.push(token);
+        }
+        i += token.replace('▁', '').length;
+        continue;
+      }
+
+      // Fallback
+      let token = text[i];
+      if (tokens.length === 0 || this.#isAfterSpace(text, i)) {
+        token = '▁' + token;
+      }
+      tokens.push(token);
+      i++;
+    }
+
+    return tokens;
+  }
+
+  #tokenizeCharacter(text: string): string[] {
+    return text.split('');
+  }
+
+  #tokenizeWhitespace(text: string): string[] {
+    return text.split(/\s+/).filter(token => token.length > 0);
+  }
+
+  #tokenizeBPE(text: string): string[] {
+    const tokens: string[] = [];
+    const words = text.split(/(\s+)/);
+
+    for (let i = 0; i < words.length; i++) {
+      const word = words[i];
+
+      if (/^\s+$/.test(word)) {
+        continue;
+      }
+
+      let tokenToProcess = word;
+      if (i > 0 && /^\s+$/.test(words[i - 1])) {
+        tokenToProcess = words[i - 1] + word;
+      }
+
+      if (tokenToProcess.length > 6) {
+        const subTokens = this.#splitIntoSubwords(tokenToProcess, 'bpe');
+        tokens.push(...subTokens);
+      } else {
+        tokens.push(tokenToProcess);
+      }
+    }
+
+    return tokens;
+  }
+
+  #tokenizeSentencePiece(text: string): string[] {
+    const tokens: string[] = [];
+    const words = text.split(/(\s+)/);
+
+    for (const word of words) {
+      if (/^\s+$/.test(word)) {
+        continue;
+      }
+
+      if (word.length > 6) {
+        const subTokens = this.#splitIntoSubwords(word, 'sentence-piece');
+        if (subTokens.length > 0) {
+          subTokens[0] = '▁' + subTokens[0];
+        }
+        tokens.push(...subTokens);
+      } else {
+        tokens.push('▁' + word);
+      }
+    }
+
+    return tokens;
+  }
+
+  #splitIntoSubwords(
+    word: string,
+    format: 'word-piece' | 'bpe' | 'sentence-piece' | 'llama' | 'character' | 'whitespace'
+  ): string[] {
+    const subTokens: string[] = [];
+    const maxLength = format === 'llama' ? 3 : 4;
+
+    for (let i = 0; i < word.length; i += maxLength) {
+      let subToken = word.slice(i, i + maxLength);
+
+      if (format === 'word-piece' && i > 0) {
+        subToken = '##' + subToken;
+      }
+
+      subTokens.push(subToken);
+    }
+
+    return subTokens;
+  }
+
+  #extractNextToken(text: string, startIndex: number): string {
+    let token = '';
+    let i = startIndex;
+    while (i < text.length && /\w/.test(text[i])) {
+      token += text[i];
+      i++;
+    }
+    return token;
+  }
+
+  #isAfterSpace(text: string, index: number): boolean {
+    return index === 0 || /\s/.test(text[index - 1]);
+  }
+}

--- a/projects/components/src/format-token/element.visual.ts
+++ b/projects/components/src/format-token/element.visual.ts
@@ -1,0 +1,27 @@
+import { html } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { visualDiff } from '@web/test-runner-visual-regression';
+import { createVisualFixture, removeFixture } from '@blueprintui/test';
+import * as formatToken from './element.examples.js';
+import '@blueprintui/components/include/format-token.js';
+
+describe('bp-format-token', () => {
+  let fixture: HTMLElement;
+
+  beforeEach(async () => {
+    fixture = await createVisualFixture(html` ${unsafeHTML(formatToken.example())} `);
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('light theme', async () => {
+    await visualDiff(fixture, 'format-token/light.png');
+  });
+
+  it('dark theme', async () => {
+    document.documentElement.setAttribute('bp-theme', 'dark');
+    await visualDiff(fixture, 'format-token/dark.png');
+  });
+});

--- a/projects/components/src/format-token/index.ts
+++ b/projects/components/src/format-token/index.ts
@@ -1,0 +1,1 @@
+export * from './element.js';

--- a/projects/components/src/include/all.ts
+++ b/projects/components/src/include/all.ts
@@ -18,6 +18,7 @@ import '@blueprintui/components/include/divider.js';
 import '@blueprintui/components/include/drawer.js';
 import '@blueprintui/components/include/dropdown.js';
 import '@blueprintui/components/include/file.js';
+import '@blueprintui/components/include/format-token.js';
 import '@blueprintui/components/include/forms.js';
 import '@blueprintui/components/include/header.js';
 import '@blueprintui/icons/include.js';

--- a/projects/components/src/include/format-token.ts
+++ b/projects/components/src/include/format-token.ts
@@ -1,0 +1,10 @@
+import { defineElement } from '@blueprintui/components/internals';
+import { BpFormatToken } from '@blueprintui/components/format-token';
+
+defineElement('bp-format-token', BpFormatToken);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'bp-format-token': BpFormatToken;
+  }
+}

--- a/projects/docs/src/_layouts/base.11ty.js
+++ b/projects/docs/src/_layouts/base.11ty.js
@@ -91,6 +91,7 @@ export function render(data) {
               <bp-tree-item ${data.page.url === '/docs/components/file.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/file.html">File</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/format-datetime.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/format-datetime.html">Format Datetime</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/format-number.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/format-number.html">Format Number</a></bp-tree-item>
+              <bp-tree-item ${data.page.url === '/docs/components/format-token.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/format-token.html">Format Token</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/forms.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/forms.html">Forms</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/form-interactions.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/form-interactions.html">Form Interactions</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/form-validation.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/form-validation.html">Form Validation</a></bp-tree-item>

--- a/projects/docs/src/_pages/components/format-token.11ty.js
+++ b/projects/docs/src/_pages/components/format-token.11ty.js
@@ -1,0 +1,21 @@
+import schema from '../../../..//components/.drafter/schema.json' with { type: 'json' };
+import { getImport, getExample, getAPI, getElementSummary } from '../../_includes/utils/index.js';
+
+export const data = {
+  title: 'Format Token',
+  schema: schema.find(c => c.name === 'format-token')
+};
+
+export function render() {
+  return /* markdown */`
+${getElementSummary(data.schema, 'bp-format-token')}
+
+${getExample(data.schema, 'example')}
+
+${getExample(data.schema, 'formats')}
+
+${getImport(data.schema)}
+
+${getAPI(data.schema)}
+`;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `bp-format-token` to visualize tokenization (WordPiece, BPE, SentencePiece, LLaMA, character, whitespace) with docs, includes, tests, and visual baselines.
> 
> - **Components**:
>   - **New** `bp-format-token` web component (`projects/components/src/format-token/element.ts`, `element.css`, `index.ts`) to render tokenized text with colored tokens; supports formats: `bpe`, `word-piece`, `sentence-piece`, `llama`, `character`, `whitespace`.
>   - Registered via `include/format-token.ts` and added to `include/all.ts`.
> - **Examples & Visuals**:
>   - Example/demo markup in `element.examples.js` and visual tests in `element.visual.ts` with new baseline screenshots (`screenshots/.../format-token/{light,dark}.png`).
> - **Tests & Performance**:
>   - Unit tests in `element.spec.ts` covering formats, styling, and content updates.
>   - Performance test `element.performance.ts` (bundle size <8kb, render <30ms).
> - **Docs**:
>   - New docs page `projects/docs/src/_pages/components/format-token.11ty.js` and nav entry in `projects/docs/src/_layouts/base.11ty.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e52b4bd096794f363d265b9aa7a7b49f61649cf3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->