### PR TITLE
Add new format to components project

### DIFF
--- a/projects/components/src/format-bytes/element.css
+++ b/projects/components/src/format-bytes/element.css
@@ -1,0 +1,7 @@
+:host {
+  display: inline;
+}
+
+[part='internal'] {
+  display: contents;
+}

--- a/projects/components/src/format-bytes/element.examples.js
+++ b/projects/components/src/format-bytes/element.examples.js
@@ -1,0 +1,90 @@
+export const metadata = {
+  name: 'format-bytes',
+  elements: ['bp-format-bytes']
+};
+
+export function example() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/format-bytes.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <bp-format-bytes>1024</bp-format-bytes>
+
+      <bp-format-bytes>1048576</bp-format-bytes>
+
+      <bp-format-bytes>1073741824</bp-format-bytes>
+    </div>
+    `;
+}
+
+export function binaryDisplay() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/format-bytes.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <bp-format-bytes display="decimal">1024</bp-format-bytes>
+
+      <bp-format-bytes display="binary">1024</bp-format-bytes>
+    </div>
+    `;
+}
+
+export function specificUnit() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/format-bytes.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <bp-format-bytes unit="kb">1048576</bp-format-bytes>
+
+      <bp-format-bytes unit="mb">1048576</bp-format-bytes>
+
+      <bp-format-bytes unit="gb">1048576</bp-format-bytes>
+    </div>
+    `;
+}
+
+export function unitDisplay() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/format-bytes.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <bp-format-bytes unit-display="short">1048576</bp-format-bytes>
+
+      <bp-format-bytes unit-display="long">1048576</bp-format-bytes>
+    </div>
+    `;
+}
+
+export function precision() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/format-bytes.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <bp-format-bytes maximum-fraction-digits="0">1234567</bp-format-bytes>
+
+      <bp-format-bytes maximum-fraction-digits="2">1234567</bp-format-bytes>
+
+      <bp-format-bytes minimum-fraction-digits="3" maximum-fraction-digits="3">1234567</bp-format-bytes>
+    </div>
+    `;
+}
+
+export function text() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/format-bytes.js';
+    </script>
+
+    <p bp-text="content">The file size is <bp-format-bytes>1048576</bp-format-bytes> which is quite large.</p>
+    `;
+}

--- a/projects/components/src/format-bytes/element.performance.ts
+++ b/projects/components/src/format-bytes/element.performance.ts
@@ -1,0 +1,16 @@
+import { testBundleSize, testRenderTime, html } from 'web-test-runner-performance/browser.js';
+import '@blueprintui/components/include/format-bytes.js';
+
+describe('bp-format-bytes performance', () => {
+  const element = html`<bp-format-bytes></bp-format-bytes>`;
+
+  it(`should bundle and treeshake under 7kb`, async () => {
+    expect(
+      (await testBundleSize('@blueprintui/components/include/format-bytes.js', { optimize: true })).kb
+    ).toBeLessThan(7);
+  });
+
+  it(`should render under 20ms`, async () => {
+    expect((await testRenderTime(element)).duration).toBeLessThan(20);
+  });
+});

--- a/projects/components/src/format-bytes/element.spec.ts
+++ b/projects/components/src/format-bytes/element.spec.ts
@@ -1,0 +1,263 @@
+import { html } from 'lit';
+import '@blueprintui/components/include/format-bytes.js';
+import { BpFormatBytes } from '@blueprintui/components/format-bytes';
+import { elementIsStable, createFixture, removeFixture } from '@blueprintui/test';
+
+describe('bp-format-bytes', () => {
+  let fixture: HTMLElement;
+  let element: BpFormatBytes;
+
+  beforeEach(async () => {
+    fixture = await createFixture(html`<bp-format-bytes></bp-format-bytes>`);
+    element = fixture.querySelector<BpFormatBytes>('bp-format-bytes');
+    await elementIsStable(element);
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('should register element', async () => {
+    await elementIsStable(element);
+    expect(customElements.get('bp-format-bytes')).toBe(BpFormatBytes);
+  });
+
+  it('should use a data tag format with a value', async () => {
+    element.value = 1024;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('data').value).toBe('1024');
+  });
+
+  it('should format bytes with decimal (1000) by default', async () => {
+    element.value = 1000;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('1 kb');
+  });
+
+  it('should format bytes with binary (1024)', async () => {
+    element.value = 1024;
+    element.display = 'binary';
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('1 kib');
+  });
+
+  it('should format zero bytes', async () => {
+    element.value = 0;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('0 b');
+  });
+
+  it('should format bytes (less than 1000)', async () => {
+    element.value = 500;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('500 b');
+  });
+
+  it('should format kilobytes', async () => {
+    element.value = 1500;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('1.5 kb');
+  });
+
+  it('should format megabytes', async () => {
+    element.value = 1500000;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('1.5 mb');
+  });
+
+  it('should format gigabytes', async () => {
+    element.value = 1500000000;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('1.5 gb');
+  });
+
+  it('should format terabytes', async () => {
+    element.value = 1500000000000;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('1.5 tb');
+  });
+
+  it('should format petabytes', async () => {
+    element.value = 1500000000000000;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('1.5 pb');
+  });
+
+  it('should format with binary units (KiB)', async () => {
+    element.value = 2048;
+    element.display = 'binary';
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('2 kib');
+  });
+
+  it('should format with binary units (MiB)', async () => {
+    element.value = 2097152; // 2 * 1024 * 1024
+    element.display = 'binary';
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('2 mib');
+  });
+
+  it('should format with binary units (GiB)', async () => {
+    element.value = 2147483648; // 2 * 1024 * 1024 * 1024
+    element.display = 'binary';
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('2 gib');
+  });
+
+  it('should format with binary units (TiB)', async () => {
+    element.value = 2199023255552; // 2 * 1024 * 1024 * 1024 * 1024
+    element.display = 'binary';
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('2 tib');
+  });
+
+  it('should format with binary units (PiB)', async () => {
+    element.value = 2251799813685248; // 2 * 1024^5
+    element.display = 'binary';
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('2 pib');
+  });
+
+  it('should format with specific unit (KB)', async () => {
+    element.value = 500;
+    element.unit = 'kb';
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('0.5 kb');
+  });
+
+  it('should format with specific unit (MB)', async () => {
+    element.value = 1500000;
+    element.unit = 'mb';
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('1.5 mb');
+  });
+
+  it('should format with specific unit (GB)', async () => {
+    element.value = 500000000;
+    element.unit = 'gb';
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('0.5 gb');
+  });
+
+  it('should format with long unit display', async () => {
+    element.value = 1500000;
+    element.unitDisplay = 'long';
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('1.5 megabytes');
+  });
+
+  it('should respect minimumFractionDigits', async () => {
+    element.value = 1500;
+    element.minimumFractionDigits = 3;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('1.500 kb');
+  });
+
+  it('should respect maximumFractionDigits', async () => {
+    element.value = 1234;
+    element.maximumFractionDigits = 0;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('1 kb');
+  });
+
+  it('should format with different locales', async () => {
+    element.value = 1500000;
+    element.locales = ['de-DE'];
+    await elementIsStable(element);
+    // German locale uses comma as decimal separator
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toContain('1,5');
+  });
+
+  it('should handle negative values', async () => {
+    element.value = -1500000;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('-1.5 mb');
+  });
+
+  it('should handle text content parsing in connectedCallback', async () => {
+    fixture = await createFixture(html`<bp-format-bytes>1024</bp-format-bytes>`);
+    element = fixture.querySelector<BpFormatBytes>('bp-format-bytes');
+    await elementIsStable(element);
+
+    expect(element.value).toBe(1024);
+  });
+
+  it('should handle bp-textchange event', async () => {
+    element.textContent = '2048';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+
+    expect(element.value).toBe(2048);
+  });
+
+  it('should handle invalid text content gracefully', async () => {
+    element.textContent = 'invalid-number';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+
+    expect(element.value).toBeNaN();
+  });
+
+  it('should handle empty text content', async () => {
+    element.textContent = '';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+
+    expect(element.value).toBeNaN();
+  });
+
+  it('should combine specific unit with binary display', async () => {
+    element.value = 512;
+    element.unit = 'kb';
+    element.display = 'binary';
+    await elementIsStable(element);
+    // 512 bytes / 1024 = 0.5 KB (using binary divisor)
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('0.5 kib');
+  });
+
+  it('should handle very large numbers', async () => {
+    element.value = 9999999999999999;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toContain('pb');
+  });
+
+  it('should handle decimal byte values', async () => {
+    element.value = 1500.5;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('1.5 kb');
+  });
+
+  it('should format with long display and multiple KB', async () => {
+    element.value = 3000;
+    element.unitDisplay = 'long';
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('3 kilobytes');
+  });
+
+  it('should format with long display for bytes', async () => {
+    element.value = 100;
+    element.unitDisplay = 'long';
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('100 bytes');
+  });
+
+  it('should handle forced unit that is larger than natural unit', async () => {
+    element.value = 100;
+    element.unit = 'gb';
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('0 gb');
+  });
+
+  it('should handle forced unit that is smaller than natural unit', async () => {
+    element.value = 1000000000;
+    element.unit = 'kb';
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('1,000,000 kb');
+  });
+
+  it('should format 1024 bytes with default decimal display', async () => {
+    element.value = 1024;
+    await elementIsStable(element);
+    expect(element.shadowRoot.querySelector('[part=internal]').textContent).toBe('1.02 kb');
+  });
+});

--- a/projects/components/src/format-bytes/element.ts
+++ b/projects/components/src/format-bytes/element.ts
@@ -1,0 +1,95 @@
+import { html, LitElement } from 'lit';
+import { property } from 'lit/decorators/property.js';
+import { baseStyles, interactionTextChange } from '@blueprintui/components/internals';
+import styles from './element.css' with { type: 'css' };
+
+/**
+ * ```typescript
+ * import '@blueprintui/components/include/format-bytes.js';
+ * ```
+ *
+ * ```html
+ * <bp-format-bytes></bp-format-bytes>
+ * ```
+ *
+ * @summary The format-bytes component is used to display byte values in a human-readable format with automatic unit conversion (b, kb, mb, gb, tb, pb).
+ * @element bp-format-bytes
+ * @since 2.9.0
+ */
+@interactionTextChange()
+export class BpFormatBytes extends LitElement {
+  @property({ type: String }) accessor display: 'decimal' | 'binary' = 'decimal';
+
+  @property({ type: String }) accessor unit: 'b' | 'kb' | 'mb' | 'gb' | 'tb' | 'pb';
+
+  @property({ type: String, attribute: 'unit-display' }) accessor unitDisplay: 'long' | 'short' = 'short';
+
+  @property({ type: Array }) accessor locales: string[];
+
+  @property({ type: Number, attribute: 'minimum-fraction-digits' }) accessor minimumFractionDigits: number = 0;
+
+  @property({ type: Number, attribute: 'maximum-fraction-digits' }) accessor maximumFractionDigits: number = 2;
+
+  @property({ type: Number }) accessor value = 0;
+
+  static styles = [baseStyles, styles];
+
+  get #divisor() {
+    return this.display === 'binary' ? 1024 : 1000;
+  }
+
+  get #units() {
+    return {
+      short: this.display === 'binary' ? ['b', 'kib', 'mib', 'gib', 'tib', 'pib'] : ['b', 'kb', 'mb', 'gb', 'tb', 'pb'],
+      long: ['bytes', 'kilobytes', 'megabytes', 'gigabytes', 'terabytes', 'petabytes']
+    };
+  }
+
+  get #formattedValue() {
+    const bytes = this.value;
+
+    if (bytes === 0) {
+      const unit = this.#units[this.unitDisplay][0];
+      return `0 ${unit}`;
+    }
+
+    const sign = bytes < 0 ? -1 : 1;
+    let unitIndex = 0;
+    let convertedValue = Math.abs(bytes);
+
+    // If a specific unit is requested, convert to that unit
+    if (this.unit) {
+      const unitMap = { b: 0, kb: 1, mb: 2, gb: 3, tb: 4, pb: 5 };
+      unitIndex = unitMap[this.unit];
+      convertedValue = Math.abs(bytes) / Math.pow(this.#divisor, unitIndex);
+    } else {
+      // Auto-detect the appropriate unit
+      while (convertedValue >= this.#divisor && unitIndex < this.#units.short.length - 1) {
+        convertedValue /= this.#divisor;
+        unitIndex++;
+      }
+    }
+
+    const formatter = new Intl.NumberFormat(this.locales, {
+      minimumFractionDigits: this.minimumFractionDigits,
+      maximumFractionDigits: Math.max(this.maximumFractionDigits, this.minimumFractionDigits)
+    });
+
+    const formattedNumber = formatter.format(sign * convertedValue);
+    const unit = this.#units[this.unitDisplay][unitIndex];
+
+    return `${formattedNumber} ${unit}`;
+  }
+
+  render() {
+    return html` <data value=${this.value} part="internal">${this.#formattedValue}</data> `;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    if (this.textContent.trim()) {
+      this.value = parseFloat(this.textContent);
+    }
+    this.addEventListener('bp-textchange', () => (this.value = parseFloat(this.textContent)));
+  }
+}

--- a/projects/components/src/format-bytes/element.ts
+++ b/projects/components/src/format-bytes/element.ts
@@ -18,16 +18,22 @@ import styles from './element.css' with { type: 'css' };
  */
 @interactionTextChange()
 export class BpFormatBytes extends LitElement {
+  /** determines the base unit system: 'decimal' (1000-based) or 'binary' (1024-based) */
   @property({ type: String }) accessor display: 'decimal' | 'binary' = 'decimal';
 
+  /** force a specific unit instead of auto-detection (b, kb, mb, gb, tb, pb) */
   @property({ type: String }) accessor unit: 'b' | 'kb' | 'mb' | 'gb' | 'tb' | 'pb';
 
+  /** determines how units are displayed: 'short' (kb), 'long' (kilobytes) */
   @property({ type: String, attribute: 'unit-display' }) accessor unitDisplay: 'long' | 'short' = 'short';
 
+  /** locales to use for number formatting */
   @property({ type: Array }) accessor locales: string[];
 
+  /** minimum number of fraction digits to display */
   @property({ type: Number, attribute: 'minimum-fraction-digits' }) accessor minimumFractionDigits: number = 0;
 
+  /** maximum number of fraction digits to display */
   @property({ type: Number, attribute: 'maximum-fraction-digits' }) accessor maximumFractionDigits: number = 2;
 
   @property({ type: Number }) accessor value = 0;

--- a/projects/components/src/format-bytes/index.ts
+++ b/projects/components/src/format-bytes/index.ts
@@ -1,0 +1,1 @@
+export * from './element.js';

--- a/projects/components/src/include/format-bytes.ts
+++ b/projects/components/src/include/format-bytes.ts
@@ -1,0 +1,10 @@
+import { BpFormatBytes } from '@blueprintui/components/format-bytes';
+import { defineElement } from '@blueprintui/components/internals';
+
+defineElement('bp-format-bytes', BpFormatBytes);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'bp-format-bytes': BpFormatBytes;
+  }
+}

--- a/projects/docs/src/_layouts/base.11ty.js
+++ b/projects/docs/src/_layouts/base.11ty.js
@@ -89,6 +89,7 @@ export function render(data) {
               <bp-tree-item ${data.page.url === '/docs/components/drawer.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/drawer.html">Drawer</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/dropdown.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/dropdown.html">Dropdown</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/file.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/file.html">File</a></bp-tree-item>
+              <bp-tree-item ${data.page.url === '/docs/components/format-bytes.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/format-bytes.html">Format Bytes</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/format-datetime.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/format-datetime.html">Format Datetime</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/format-number.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/format-number.html">Format Number</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/format-token.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/format-token.html">Format Token</a></bp-tree-item>

--- a/projects/docs/src/_pages/components/format-bytes.11ty.js
+++ b/projects/docs/src/_pages/components/format-bytes.11ty.js
@@ -1,0 +1,29 @@
+import schema from '../../../..//components/.drafter/schema.json' with { type: 'json' };
+import { getImport, getExample, getAPI, getElementSummary } from '../../_includes/utils/index.js';
+
+export const data = {
+  title: 'Format Bytes',
+  schema: schema.find(c => c.name === 'format-bytes')
+};
+
+export function render() {
+  return /* markdown */`
+${getElementSummary(data.schema, 'bp-format-bytes')}
+
+${getExample(data.schema, 'example')}
+
+${getExample(data.schema, 'binary-display')}
+
+${getExample(data.schema, 'specific-unit')}
+
+${getExample(data.schema, 'unit-display')}
+
+${getExample(data.schema, 'precision')}
+
+${getExample(data.schema, 'text')}
+
+${getImport(data.schema)}
+
+${getAPI(data.schema)}
+`;
+}


### PR DESCRIPTION
Add new bp-format-bytes component that formats byte values into human-readable storage units (B, KB, MB, GB, TB, PB). The component follows the same API patterns as format-number and format-datetime components.

Features:
- Automatic unit conversion based on byte value
- Support for decimal (1000-based) and binary (1024-based) formatting
- Configurable unit display (short, long, narrow)
- Manual unit selection (B, KB, MB, GB, TB, PB)
- Locale-aware number formatting
- Configurable fraction digits for precision control
- Text content parsing via bp-textchange event

Files added:
- element.ts: Main component implementation
- element.css: Component styles
- element.spec.ts: Comprehensive unit tests
- element.examples.js: Documentation examples
- element.performance.ts: Performance benchmarks
- index.ts: Module export
- include/format-bytes.ts: Component registration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `bp-format-bytes` to format byte values with decimal/binary units, configurable unit display and precision, plus tests, examples, and docs.
> 
> - **Components**:
>   - Add `bp-format-bytes` with implementation and styles (`projects/components/src/format-bytes/element.ts`, `element.css`, `index.ts`, `include/format-bytes.ts`).
>   - Supports decimal/binary units, forced `unit`, `unit-display` short/long, `locales`, `minimum/maximum-fraction-digits`, and text parsing via `bp-textchange`.
> - **Tests**:
>   - Add unit tests (`element.spec.ts`) and performance tests (`element.performance.ts`).
> - **Docs**:
>   - Add docs page (`projects/docs/src/_pages/components/format-bytes.11ty.js`) and update nav (`projects/docs/src/_layouts/base.11ty.js`).
> - **Examples**:
>   - Add examples (`projects/components/src/format-bytes/element.examples.js`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cd592b590e68a936c84987faa571b2d6c694a3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->