### PR TITLE
Add hover effect to grid columns

### DIFF
--- a/projects/grid/src/grid/hover.controller.ts
+++ b/projects/grid/src/grid/hover.controller.ts
@@ -13,7 +13,7 @@ export class GridHoverController implements ReactiveController {
   async hostConnected() {
     await this.host.updateComplete;
     this.#initializeColumnHoverState();
-    this.host.addEventListener('mouseout', () => this.#removeHoverStyles());
+    this.host.addEventListener('mouseleave', () => this.#removeHoverStyles());
   }
 
   hostUpdated() {
@@ -31,8 +31,8 @@ export class GridHoverController implements ReactiveController {
           const index =
             Array.from(cell.parentElement.querySelectorAll('bp-grid-cell, bp-grid-column')).indexOf(cell) + 1;
           (this.#columnStyles as any).replaceSync(/* css */ `
-            bp-grid[_id=${this.host._id}] bp-grid-cell:nth-child(${index}),
-            bp-grid[_id=${this.host._id}] bp-grid-column:nth-child(${index}) {
+            bp-grid[_id=${this.host._id}] bp-grid-cell:nth-of-type(${index}),
+            bp-grid[_id=${this.host._id}] bp-grid-column:nth-of-type(${index}) {
               --bp-interaction-offset: var(--bp-interaction-hover-offset);
             }
           `);


### PR DESCRIPTION
The column hover feature was not working when both row-style="hover" and column-style="hover" were enabled simultaneously. The issue was caused by using :nth-child() selector which counts all child nodes (including whitespace text nodes), while the index calculation only counted element nodes.

Changed :nth-child() to :nth-of-type() which counts only elements of the same type, matching the index calculation logic.

This allows both row and column hover effects to work independently and simultaneously as intended.