### PR TITLE
Add bp-avatar component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 _site
 dist
 .wireit
+.wireit-cache-validate
 .DS_store
 .firebase
 .eslintcache

--- a/projects/components/screenshots/Chromium/baseline/avatar/dark.png
+++ b/projects/components/screenshots/Chromium/baseline/avatar/dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b28476c63236eac42d084ab58a27841ed4236271a1b245d4863b873ffe143156
+size 13318

--- a/projects/components/screenshots/Chromium/baseline/avatar/light.png
+++ b/projects/components/screenshots/Chromium/baseline/avatar/light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d024cf4832406d9614ea2db923d1f9653629bdb40a689fec58392ca118cc306e
+size 13565

--- a/projects/components/src/avatar/element.css
+++ b/projects/components/src/avatar/element.css
@@ -1,0 +1,66 @@
+:host {
+  --size: var(--bp-size-800);
+  --background: var(--bp-object-opacity-200);
+  --color: var(--bp-text-color-400);
+  --border-radius: 100%;
+  --font-size: var(--bp-text-size-200);
+  --padding: var(--bp-size-200);
+  display: inline-flex;
+  position: relative;
+}
+
+[part='internal'] {
+  --icon-color: var(--color);
+  background: var(--background);
+  color: var(--color);
+  width: var(--size);
+  height: var(--size);
+  border-radius: var(--border-radius);
+  font-size: var(--font-size);
+  padding: var(--padding);
+  position: relative;
+  place-items: center;
+  place-content: center;
+  display: flex;
+  flex-shrink: 0;
+  font-weight: 500;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+slot {
+  border-radius: var(--border-radius);
+  line-height: var(--size);
+  place-items: center;
+  place-content: center;
+  display: flex;
+  overflow: hidden;
+}
+
+:host([shape='square']) {
+  --border-radius: 0;
+}
+
+:host([shape='rounded']) {
+  --border-radius: var(--bp-object-border-radius-100);
+}
+
+bp-badge {
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+::slotted(img) {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+bp-icon,
+::slotted(bp-icon) {
+  --color: var(--icon-color);
+  width: calc(var(--size) * 0.5);
+  height: calc(var(--size) * 0.5);
+}

--- a/projects/components/src/avatar/element.examples.js
+++ b/projects/components/src/avatar/element.examples.js
@@ -1,0 +1,185 @@
+export const metadata = {
+  name: 'avatar',
+  elements: ['bp-avatar']
+};
+
+/**
+ * @summary Basic avatar usage with icon, text initials, and image content options
+ */
+export function example() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/avatar.js';
+      import '@blueprintui/icons/shapes/user.js';
+    </script>
+
+    <div bp-layout="inline gap:sm">
+      <bp-avatar aria-label="User avatar">
+        <bp-icon shape="user" type="solid"></bp-icon>
+      </bp-avatar>
+      <bp-avatar aria-label="John Doe">JD</bp-avatar>
+      <bp-avatar>
+        <img src="/assets/images/browsers/chrome.svg" alt="chrome browser" loading="lazy" />
+      </bp-avatar>
+    </div>
+    `;
+}
+
+/**
+ * @summary Avatar shape variants including circle (default), square, and rounded styles
+ */
+export function shapes() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/avatar.js';
+      import '@blueprintui/icons/shapes/user.js';
+    </script>
+
+    <div bp-layout="inline gap:sm">
+      <bp-avatar aria-label="default avatar"></bp-avatar>
+      <bp-avatar shape="square" aria-label="square avatar"></bp-avatar>
+      <bp-avatar shape="rounded" aria-label="rounded avatar"></bp-avatar>
+    </div>
+    `;
+}
+
+/**
+ * @summary Status indicators for user presence or state using accent, success, warning, and danger colors
+ */
+export function status() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/avatar.js';
+    </script>
+
+    <div bp-layout="inline gap:sm">
+      <bp-avatar aria-label="Default user"></bp-avatar>
+      <bp-avatar status="accent" aria-label="User with accent status"></bp-avatar>
+      <bp-avatar status="success" aria-label="Online user"></bp-avatar>
+      <bp-avatar status="warning" aria-label="User with warning"></bp-avatar>
+      <bp-avatar status="danger" aria-label="User with danger status"></bp-avatar>
+    </div>
+    `;
+}
+
+/**
+ * @summary Custom avatar sizing using CSS variables with small, medium, and large examples
+ */
+export function sizes() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/avatar.js';
+    </script>
+
+    <div bp-layout="inline gap:sm">
+      <bp-avatar aria-label="small avatar" style="--size: var(--bp-size-700)"></bp-avatar>
+      <bp-avatar aria-label="medium avatar"></bp-avatar>
+      <bp-avatar aria-label="large avatar" style="--size: var(--bp-size-900)"></bp-avatar>
+    </div>
+    `;
+}
+
+/**
+ * @summary Text-based avatars displaying user initials as content for multiple users
+ */
+export function initials() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/avatar.js';
+    </script>
+
+    <div bp-layout="inline gap:sm">
+      <bp-avatar aria-label="John Doe">JD</bp-avatar>
+      <bp-avatar aria-label="Sarah Smith">SS</bp-avatar>
+      <bp-avatar aria-label="Mike Johnson">MJ</bp-avatar>
+      <bp-avatar aria-label="Emily Brown">EB</bp-avatar>
+    </div>
+    `;
+}
+
+/**
+ * @summary Image-based avatars using the default slot for custom graphics or photos
+ */
+export function images() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/avatar.js';
+    </script>
+
+    <div bp-layout="inline gap:sm">
+      <bp-avatar>
+        <img src="/assets/images/browsers/safari.svg" alt="safari browser" loading="lazy" />
+      </bp-avatar>
+      <bp-avatar>
+        <img src="/assets/images/browsers/firefox.svg" alt="firefox browser" loading="lazy" />
+      </bp-avatar>
+      <bp-avatar>
+        <img src="/assets/images/browsers/edge.svg" alt="edge browser" loading="lazy" />
+      </bp-avatar>
+      <bp-avatar>
+        <img src="/assets/images/browsers/chrome.svg" alt="chrome browser" loading="lazy" />
+      </bp-avatar>
+    </div>
+    `;
+}
+
+/**
+ * @summary Icon-based avatars demonstrating different entity types like users, organizations, teams, and settings
+ */
+export function icons() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/avatar.js';
+      import '@blueprintui/icons/include.js';
+      import '@blueprintui/icons/shapes/user.js';
+      import '@blueprintui/icons/shapes/building.js';
+      import '@blueprintui/icons/shapes/employee-group.js';
+      import '@blueprintui/icons/shapes/cog.js';
+    </script>
+
+    <div bp-layout="inline gap:sm">
+      <bp-avatar aria-label="User">
+        <bp-icon shape="user" type="solid"></bp-icon>
+      </bp-avatar>
+      <bp-avatar aria-label="Organization">
+        <bp-icon shape="building" type="solid"></bp-icon>
+      </bp-avatar>
+      <bp-avatar aria-label="Team">
+        <bp-icon shape="employee-group" type="solid"></bp-icon>
+      </bp-avatar>
+      <bp-avatar aria-label="Settings">
+        <bp-icon shape="cog" type="solid"></bp-icon>
+      </bp-avatar>
+    </div>
+    `;
+}
+
+/**
+ * @summary Stacked avatar group pattern with overlapping layout and overflow count indicator
+ */
+export function group() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/avatar.js';
+    </script>
+
+    <div class="avatar-group" bp-layout="inline">
+      <bp-avatar>
+        <img src="/assets/images/browsers/safari.svg" alt="safari browser" loading="lazy" />
+      </bp-avatar>
+      <bp-avatar>
+        <img src="/assets/images/browsers/firefox.svg" alt="firefox browser" loading="lazy" />
+      </bp-avatar>
+      <bp-avatar>
+        <img src="/assets/images/browsers/chrome.svg" alt="chrome browser" loading="lazy" />
+      </bp-avatar>
+      <bp-avatar aria-label="More users">+5</bp-avatar>
+    </div>
+
+    <style>
+      .avatar-group bp-avatar:not(:last-of-type) {
+        margin-right: calc(-1 * var(--bp-space-xs));
+      }
+    </style>
+    `;
+}

--- a/projects/components/src/avatar/element.performance.ts
+++ b/projects/components/src/avatar/element.performance.ts
@@ -1,0 +1,16 @@
+import { testBundleSize, testRenderTime, html } from 'web-test-runner-performance/browser.js';
+import '@blueprintui/components/include/avatar.js';
+
+describe('bp-avatar performance', () => {
+  const element = html`<bp-avatar aria-label="User">JD</bp-avatar>`;
+
+  it(`should bundle and treeshake under 8.5kb`, async () => {
+    expect((await testBundleSize('@blueprintui/components/include/avatar.js', { optimize: true })).kb).toBeLessThan(
+      8.5
+    );
+  });
+
+  it(`should render under 20ms`, async () => {
+    expect((await testRenderTime(element)).duration).toBeLessThan(20);
+  });
+});

--- a/projects/components/src/avatar/element.spec.ts
+++ b/projects/components/src/avatar/element.spec.ts
@@ -1,0 +1,128 @@
+import { html } from 'lit';
+import '@blueprintui/components/include/avatar.js';
+import { BpAvatar } from '@blueprintui/components/avatar';
+import { elementIsStable, createFixture, removeFixture } from '@blueprintui/test';
+
+describe('bp-avatar', () => {
+  let fixture: HTMLElement;
+  let element: BpAvatar;
+
+  beforeEach(async () => {
+    fixture = await createFixture(html`<bp-avatar aria-label="Test User">TU</bp-avatar>`);
+    element = fixture.querySelector<BpAvatar>('bp-avatar');
+    await elementIsStable(element);
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('should register element', async () => {
+    await elementIsStable(element);
+    expect(customElements.get('bp-avatar')).toBe(BpAvatar);
+  });
+
+  it('should default to circle shape (default)', async () => {
+    await elementIsStable(element);
+    expect(element.shape).toBe(undefined);
+    expect(element.getAttribute('shape')).toBe(null);
+  });
+
+  it('should default to no status', async () => {
+    await elementIsStable(element);
+    expect(element.status).toBe(undefined);
+    expect(element.getAttribute('status')).toBe(null);
+  });
+
+  it('should handle shape property changes', async () => {
+    await elementIsStable(element);
+    element.shape = 'square';
+    await elementIsStable(element);
+
+    expect(element.shape).toBe('square');
+    expect(element.getAttribute('shape')).toBe('square');
+
+    element.shape = 'rounded';
+    await elementIsStable(element);
+
+    expect(element.shape).toBe('rounded');
+    expect(element.getAttribute('shape')).toBe('rounded');
+  });
+
+  it('should handle status property changes', async () => {
+    await elementIsStable(element);
+    element.status = 'success';
+    await elementIsStable(element);
+
+    expect(element.status).toBe('success');
+    expect(element.getAttribute('status')).toBe('success');
+
+    element.status = 'danger';
+    await elementIsStable(element);
+
+    expect(element.status).toBe('danger');
+    expect(element.getAttribute('status')).toBe('danger');
+  });
+
+  it('should render slot content', async () => {
+    await elementIsStable(element);
+    expect(element.innerText).toBe('TU');
+  });
+
+  it('should allow CSS custom properties to be overridden', async () => {
+    element.style.setProperty('--size', '64px');
+    element.style.setProperty('--background', 'red');
+    element.style.setProperty('--color', 'white');
+
+    await elementIsStable(element);
+
+    expect(element.style.getPropertyValue('--size')).toBe('64px');
+    expect(element.style.getPropertyValue('--background')).toBe('red');
+    expect(element.style.getPropertyValue('--color')).toBe('white');
+  });
+
+  it('should handle image content', async () => {
+    const imgFixture = await createFixture(html`
+      <bp-avatar>
+        <img src="test.jpg" alt="Test User" />
+      </bp-avatar>
+    `);
+    const imgElement = imgFixture.querySelector<BpAvatar>('bp-avatar');
+    const img = imgElement.querySelector('img');
+
+    await elementIsStable(imgElement);
+
+    expect(img).toBeDefined();
+    expect(img.getAttribute('src')).toBe('test.jpg');
+    expect(img.getAttribute('alt')).toBe('Test User');
+
+    removeFixture(imgFixture);
+  });
+
+  it('should set role to img', async () => {
+    await elementIsStable(element);
+    expect(element._internals.role).toBe('img');
+  });
+
+  it('should support multiple shape values', async () => {
+    const shapes: ('square' | 'rounded')[] = ['square', 'rounded'];
+
+    for (const shape of shapes) {
+      element.shape = shape;
+      await elementIsStable(element);
+      expect(element.shape).toBe(shape);
+      expect(element.getAttribute('shape')).toBe(shape);
+    }
+  });
+
+  it('should support multiple status values', async () => {
+    const statuses: ('accent' | 'success' | 'warning' | 'danger')[] = ['accent', 'success', 'warning', 'danger'];
+
+    for (const status of statuses) {
+      element.status = status;
+      await elementIsStable(element);
+      expect(element.status).toBe(status);
+      expect(element.getAttribute('status')).toBe(status);
+    }
+  });
+});

--- a/projects/components/src/avatar/element.ts
+++ b/projects/components/src/avatar/element.ts
@@ -1,0 +1,54 @@
+import { html, LitElement, nothing } from 'lit';
+import { property } from 'lit/decorators/property.js';
+import { attachInternals, baseStyles } from '@blueprintui/components/internals';
+import styles from './element.css' with { type: 'css' };
+
+/**
+ * ```typescript
+ * import '@blueprintui/components/include/avatar.js';
+ * ```
+ *
+ * ```html
+ * <bp-avatar aria-label="User avatar">
+ *   <bp-icon shape="user" type="solid"></bp-icon>
+ * </bp-avatar>
+ * ```
+ *
+ * @summary The avatar component is used to represent a user or entity with an image, icon, or initials
+ * @element bp-avatar
+ * @since 2.9.0
+ * @slot - Content to display - text for initials, img for image, or icon for custom icon
+ * @cssprop --size - Size of the avatar (default: var(--bp-size-900))
+ * @cssprop --background - Background color
+ * @cssprop --color - Text/icon color
+ * @cssprop --border-radius - Border radius (controlled by shape attribute)
+ * @csspart internal - The container wrapping the avatar content
+ */
+export class BpAvatar extends LitElement {
+  static styles = [baseStyles, styles];
+
+  /** determine the visual shape of the avatar */
+  @property({ type: String, reflect: true }) accessor shape: 'square' | 'rounded';
+
+  /** optional status indicator color */
+  @property({ type: String, reflect: true }) accessor status: 'accent' | 'success' | 'warning' | 'danger';
+
+  declare _internals: ElementInternals;
+
+  render() {
+    return html`
+      <div part="internal">
+        <slot>
+          ${this.status ? html`<bp-badge .status=${this.status}></bp-badge>` : nothing}
+          <bp-icon shape="user" type="solid"></bp-icon>
+        </slot>
+      </div>
+    `;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    attachInternals(this);
+    this._internals.role = 'img';
+  }
+}

--- a/projects/components/src/avatar/element.visual.ts
+++ b/projects/components/src/avatar/element.visual.ts
@@ -1,0 +1,30 @@
+import { html } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { visualDiff } from '@web/test-runner-visual-regression';
+import { createVisualFixture, removeFixture } from '@blueprintui/test';
+import * as avatar from './element.examples.js';
+import '@blueprintui/components/include/avatar.js';
+
+describe('bp-avatar', () => {
+  let fixture: HTMLElement;
+
+  beforeEach(async () => {
+    fixture = await createVisualFixture(html`
+      ${unsafeHTML(avatar.example())} ${unsafeHTML(avatar.shapes())} ${unsafeHTML(avatar.status())}
+      ${unsafeHTML(avatar.sizes())} ${unsafeHTML(avatar.initials())} ${unsafeHTML(avatar.icons())}
+    `);
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('light theme', async () => {
+    await visualDiff(fixture, 'avatar/light.png');
+  });
+
+  it('dark theme', async () => {
+    document.documentElement.setAttribute('bp-theme', 'dark');
+    await visualDiff(fixture, 'avatar/dark.png');
+  });
+});

--- a/projects/components/src/avatar/index.ts
+++ b/projects/components/src/avatar/index.ts
@@ -1,0 +1,1 @@
+export * from './element.js';

--- a/projects/components/src/include/all.ts
+++ b/projects/components/src/include/all.ts
@@ -1,5 +1,6 @@
 import '@blueprintui/components/include/accordion.js';
 import '@blueprintui/components/include/alert.js';
+import '@blueprintui/components/include/avatar.js';
 import '@blueprintui/components/include/badge.js';
 import '@blueprintui/components/include/breadcrumb.js';
 import '@blueprintui/components/include/button-expand.js';

--- a/projects/components/src/include/avatar.ts
+++ b/projects/components/src/include/avatar.ts
@@ -1,0 +1,13 @@
+import { BpAvatar } from '@blueprintui/components/avatar';
+import { defineElement } from '@blueprintui/components/internals';
+import '@blueprintui/components/include/badge.js';
+import '@blueprintui/icons/include.js';
+import '@blueprintui/icons/shapes/user.js';
+
+defineElement('bp-avatar', BpAvatar);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'bp-avatar': BpAvatar;
+  }
+}

--- a/projects/components/src/index.performance.ts
+++ b/projects/components/src/index.performance.ts
@@ -4,6 +4,6 @@ describe('performance', () => {
   it(`should bundle and treeshake all components`, async () => {
     expect(
       (await testBundleSize(`import '@blueprintui/components/include/all.js'`, { optimize: true })).kb
-    ).toBeLessThan(33.9);
+    ).toBeLessThan(34.5);
   });
 });

--- a/projects/docs/src/_layouts/base.11ty.js
+++ b/projects/docs/src/_layouts/base.11ty.js
@@ -69,6 +69,7 @@ export function render(data) {
               <bp-tree-item ${data.page.url === '/docs/components/accordion.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/accordion.html">Accordion</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/alert.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/alert.html">Alert</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/alert-group.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/alert-group.html">Alert Group</a></bp-tree-item>
+              <bp-tree-item ${data.page.url === '/docs/components/avatar.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/avatar.html">Avatar</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/badge.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/badge.html">Badge</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/breadcrumb.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/breadcrumb.html">Breadcrumb</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/button.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/button.html">Button</a></bp-tree-item>

--- a/projects/docs/src/_pages/components/avatar.11ty.js
+++ b/projects/docs/src/_pages/components/avatar.11ty.js
@@ -1,0 +1,40 @@
+import schema from '../../../../components/.drafter/schema.json' with { type: 'json' };
+import { getImport, getExample, getAPI, getElementSummary } from '../../_includes/utils/index.js';
+
+export const data = {
+  title: 'Avatar',
+  schema: schema.find(c => c.name === 'avatar')
+};
+
+export function render() {
+  return /* markdown */`
+${getElementSummary(data.schema, 'bp-avatar')}
+
+${getExample(data.schema, 'example')}
+
+${getExample(data.schema, 'shapes')}
+
+${getExample(data.schema, 'status')}
+
+${getExample(data.schema, 'sizes')}
+
+${getExample(data.schema, 'initials')}
+
+${getExample(data.schema, 'images')}
+
+${getExample(data.schema, 'icons')}
+
+${getExample(data.schema, 'group')}
+
+${getImport(data.schema)}
+
+## Accessibility
+
+- When slotting an \`<img>\`, use the \`alt\` attribute for accessibility
+- For non-image content (initials, icons), use the standard \`aria-label\` attribute on \`<bp-avatar>\` for accessibility
+- Image loading behavior (lazy/eager) is controlled via the standard \`loading\` attribute on the slotted \`<img>\` tag
+- The component automatically sets \`role="img"\` for proper semantics
+
+${getAPI(data.schema)}
+`;
+}


### PR DESCRIPTION
Implement new bp-avatar component for displaying user avatars with:
- Support for images, initials, and icons via default slot
- Three shape variants: circle (default), square, and rounded
- Status indicator with accent, success, warning, and danger colors
- Customizable size via CSS custom properties
- Full accessibility support with aria-label and role="img"
- Comprehensive test coverage (unit, visual, performance)
- Complete documentation with multiple usage examples

Component includes:
- TypeScript implementation following Lit patterns
- CSS with design token integration
- Unit tests with Jasmine
- Visual regression tests for light/dark themes
- Performance benchmarks
- Documentation with shape, status, size, and group examples