### PR TITLE
Add bp-skeleton component

### DIFF
--- a/projects/components/screenshots/Chromium/baseline/skeleton/dark.png
+++ b/projects/components/screenshots/Chromium/baseline/skeleton/dark.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6049859a5e9b30eb691db8896c0b4aefc50b41a49057a09bca9b93be5bb8585
+size 13801

--- a/projects/components/screenshots/Chromium/baseline/skeleton/light.png
+++ b/projects/components/screenshots/Chromium/baseline/skeleton/light.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dd59ca5f5d680bba41243eb42b62a1c48036335900747db734d9613f386d8c6
+size 9486

--- a/projects/components/src/include/all.ts
+++ b/projects/components/src/include/all.ts
@@ -41,6 +41,7 @@ import '@blueprintui/components/include/range.js';
 import '@blueprintui/components/include/rating.js';
 import '@blueprintui/components/include/search.js';
 import '@blueprintui/components/include/select.js';
+import '@blueprintui/components/include/skeleton.js';
 import '@blueprintui/components/include/switch.js';
 import '@blueprintui/components/include/tabs.js';
 import '@blueprintui/components/include/tag.js';

--- a/projects/components/src/include/lazy.ts
+++ b/projects/components/src/include/lazy.ts
@@ -40,6 +40,7 @@ export const loader = {
   rating: () => import('@blueprintui/components/include/rating.js'),
   search: () => import('@blueprintui/components/include/search.js'),
   select: () => import('@blueprintui/components/include/select.js'),
+  skeleton: () => import('@blueprintui/components/include/skeleton.js'),
   stepper: () => import('@blueprintui/components/include/stepper.js'),
   switch: () => import('@blueprintui/components/include/switch.js'),
   tabs: () => import('@blueprintui/components/include/tabs.js'),

--- a/projects/components/src/include/skeleton.ts
+++ b/projects/components/src/include/skeleton.ts
@@ -1,0 +1,10 @@
+import { defineElement } from '@blueprintui/components/internals';
+import { BpSkeleton } from '@blueprintui/components/skeleton';
+
+defineElement('bp-skeleton', BpSkeleton);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'bp-skeleton': BpSkeleton;
+  }
+}

--- a/projects/components/src/skeleton/element.css
+++ b/projects/components/src/skeleton/element.css
@@ -1,0 +1,62 @@
+:host {
+  --width: 100%;
+  --height: 1rem;
+  --background: var(--bp-layer-background-200);
+  --border-radius: var(--bp-object-border-radius-100);
+  --animation-duration: calc(var(--bp-animation-duration-300) * 5);
+  display: inline-block;
+  width: var(--width);
+  height: var(--height);
+}
+
+[part='internal'] {
+  display: block;
+  width: 100%;
+  height: 100%;
+  background: var(--background);
+  border-radius: var(--border-radius);
+  position: relative;
+  overflow: hidden;
+}
+
+:host([shape='circle']) {
+  --border-radius: 50%;
+}
+
+/* Pulse effect */
+:host([effect='pulse']) [part='internal'] {
+  animation: bp-skeleton-pulse var(--animation-duration) ease-in-out infinite;
+}
+
+@keyframes bp-skeleton-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.4;
+  }
+}
+
+:host([effect='sheen']) [part='internal']::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  /* stylelint-disable-next-line */
+  background: linear-gradient(90deg, transparent 0%, hsl(from currentColor h s l / 0.2) 50%, transparent 100%);
+  animation: bp-skeleton-sheen var(--animation-duration) ease-in-out infinite;
+}
+
+@keyframes bp-skeleton-sheen {
+  0% {
+    transform: translateX(-100%);
+  }
+
+  100% {
+    transform: translateX(100%);
+  }
+}

--- a/projects/components/src/skeleton/element.examples.js
+++ b/projects/components/src/skeleton/element.examples.js
@@ -1,0 +1,144 @@
+export const metadata = {
+  name: 'skeleton',
+  elements: ['bp-skeleton']
+};
+
+/** @summary Basic skeleton loader with default rectangular shape and shimmer effect */
+export function example() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/skeleton.js';
+    </script>
+
+    <bp-skeleton></bp-skeleton>
+  `;
+}
+
+/** @summary Demonstrates animation effects including shimmer (default), pulse, and sheen for different loading patterns */
+export function effect() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/skeleton.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <bp-skeleton></bp-skeleton>
+      <bp-skeleton effect="pulse"></bp-skeleton>
+      <bp-skeleton effect="sheen"></bp-skeleton>
+    </div>
+  `;
+}
+
+/** @summary Shows rectangular and circular shapes for different content types like images or avatars */
+export function shape() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/skeleton.js';
+    </script>
+
+    <div bp-layout="inline gap:md">
+      <bp-skeleton style="--width: 200px; --height: 100px"></bp-skeleton>
+      <bp-skeleton shape="circle" style="--width: 100px; --height: 100px"></bp-skeleton>
+    </div>
+  `;
+}
+
+/** @summary Custom dimensions using CSS variables to match specific content widths and heights */
+export function customSize() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/skeleton.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <bp-skeleton style="--width: 100px; --height: 16px"></bp-skeleton>
+      <bp-skeleton style="--width: 200px; --height: 20px"></bp-skeleton>
+      <bp-skeleton style="--width: 150px; --height: 24px"></bp-skeleton>
+    </div>
+  `;
+}
+
+/** @summary Avatar placeholders with circular shape and pulse effect in multiple sizes using design tokens */
+export function avatar() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/skeleton.js';
+    </script>
+
+    <div bp-layout="inline gap:md">
+      <bp-skeleton shape="circle" effect="pulse" style="--width: var(--bp-size-700); --height: var(--bp-size-700)"></bp-skeleton>
+      <bp-skeleton shape="circle" effect="pulse" style="--width: var(--bp-size-800); --height: var(--bp-size-800)"></bp-skeleton>
+      <bp-skeleton shape="circle" effect="pulse" style="--width: var(--bp-size-900); --height: var(--bp-size-900)"></bp-skeleton>
+    </div>
+  `;
+}
+
+/** @summary Text paragraph placeholder with varied line widths to simulate natural text flow */
+export function textLines() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/skeleton.js';
+    </script>
+
+    <div style="display: flex; flex-direction: column; gap: var(--bp-space-sm);">
+      <bp-skeleton effect="sheen" style="--width: 100%"></bp-skeleton>
+      <bp-skeleton effect="sheen" style="--width: 80%"></bp-skeleton>
+      <bp-skeleton effect="sheen" style="--width: 90%"></bp-skeleton>
+      <bp-skeleton effect="sheen" style="--width: 75%"></bp-skeleton>
+    </div>
+  `;
+}
+
+/** @summary Card layout pattern combining circular avatar with text lines for user profile or list item placeholders */
+export function cardLayout() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/skeleton.js';
+    </script>
+
+    <div style="display: flex; gap: var(--bp-space-md); padding: var(--bp-space-md); max-width: 400px;">
+      <bp-skeleton shape="circle" effect="pulse" style="--width: 60px; --height: 60px"></bp-skeleton>
+      <div style="flex: 1; display: flex; flex-direction: column; gap: var(--bp-space-sm);">
+        <bp-skeleton effect="sheen" style="--width: 40%; --height: 1.2rem"></bp-skeleton>
+        <bp-skeleton effect="sheen" style="--width: 100%; --height: 1rem"></bp-skeleton>
+        <bp-skeleton effect="sheen" style="--width: 75%; --height: 1rem"></bp-skeleton>
+      </div>
+    </div>
+  `;
+}
+
+/** @summary Image card pattern with large image placeholder and text lines for media gallery or blog post previews */
+export function imageLayout() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/skeleton.js';
+    </script>
+
+    <div bp-layout="block gap:md" style="max-width: 300px;">
+      <bp-skeleton effect="sheen" style="--width: 100%; --height: 200px"></bp-skeleton>
+      <bp-skeleton effect="sheen" style="--width: 60%; --height: 1.5rem"></bp-skeleton>
+      <bp-skeleton effect="sheen" style="--width: 100%; --height: 1rem"></bp-skeleton>
+      <bp-skeleton effect="sheen" style="--width: 85%; --height: 1rem"></bp-skeleton>
+    </div>
+  `;
+}
+
+/** @summary Custom background colors using design token variables to match brand themes or specific UI contexts */
+export function customColors() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/skeleton.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <bp-skeleton
+        effect="pulse"
+        style="--width: 100%; --height: 40px; --background: var(--bp-status-accent-background-200)">
+      </bp-skeleton>
+      <bp-skeleton
+        effect="pulse"
+        style="--width: 100%; --height: 40px; --background: var(--bp-status-success-background-200)">
+      </bp-skeleton>
+    </div>
+  `;
+}

--- a/projects/components/src/skeleton/element.performance.ts
+++ b/projects/components/src/skeleton/element.performance.ts
@@ -1,0 +1,16 @@
+import { testBundleSize, testRenderTime, html } from 'web-test-runner-performance/browser.js';
+import '@blueprintui/components/include/skeleton.js';
+
+describe('bp-skeleton performance', () => {
+  const element = html` <bp-skeleton effect="pulse" shape="rect"></bp-skeleton> `;
+
+  it(`should bundle and treeshake under 6.5kb`, async () => {
+    expect((await testBundleSize('@blueprintui/components/include/skeleton.js', { optimize: true })).kb).toBeLessThan(
+      6.5
+    );
+  });
+
+  it(`should render under 20ms`, async () => {
+    expect((await testRenderTime(element)).duration).toBeLessThan(20);
+  });
+});

--- a/projects/components/src/skeleton/element.spec.ts
+++ b/projects/components/src/skeleton/element.spec.ts
@@ -1,0 +1,83 @@
+import { html } from 'lit';
+import { elementIsStable, createFixture, removeFixture } from '@blueprintui/test';
+import { BpSkeleton } from '@blueprintui/components/skeleton';
+import '@blueprintui/components/include/skeleton.js';
+
+describe('skeleton element', () => {
+  let fixture: HTMLElement;
+  let element: BpSkeleton;
+
+  beforeEach(async () => {
+    fixture = await createFixture(html`<bp-skeleton></bp-skeleton>`);
+    element = fixture.querySelector<BpSkeleton>('bp-skeleton');
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('should create the component', async () => {
+    await elementIsStable(element);
+    expect(element).toBeTruthy();
+  });
+
+  it('should register the component', async () => {
+    await elementIsStable(element);
+    expect(customElements.get('bp-skeleton')).toBe(BpSkeleton);
+  });
+
+  it('should have default property values', async () => {
+    await elementIsStable(element);
+    expect(element.effect).toBe(undefined);
+    expect(element.shape).toBe(undefined);
+  });
+
+  it('should set effect property', async () => {
+    element.effect = 'pulse';
+    await elementIsStable(element);
+    expect(element.effect).toBe('pulse');
+    expect(element.hasAttribute('effect')).toBe(true);
+    expect(element.getAttribute('effect')).toBe('pulse');
+  });
+
+  it('should set shape property', async () => {
+    element.shape = 'circle';
+    await elementIsStable(element);
+    expect(element.shape).toBe('circle');
+    expect(element.hasAttribute('shape')).toBe(true);
+    expect(element.getAttribute('shape')).toBe('circle');
+  });
+
+  it('should update effect through attribute', async () => {
+    element.setAttribute('effect', 'sheen');
+    await elementIsStable(element);
+    expect(element.effect).toBe('sheen');
+  });
+
+  it('should update shape through attribute', async () => {
+    element.setAttribute('shape', 'circle');
+    await elementIsStable(element);
+    expect(element.shape).toBe('circle');
+  });
+
+  it('should have the internal part', async () => {
+    await elementIsStable(element);
+    const internal = element.shadowRoot?.querySelector('[part="internal"]');
+    expect(internal).toBeTruthy();
+  });
+
+  it('should have presentation role', async () => {
+    await elementIsStable(element);
+    expect(element._internals.role).toBe('presentation');
+  });
+
+  it('should have aria-live polite', async () => {
+    await elementIsStable(element);
+    expect(element._internals.ariaLive).toBe('polite');
+  });
+
+  it('should have aria-label', async () => {
+    await elementIsStable(element);
+    expect(element._internals.ariaLabel).toBe('Loading content');
+  });
+});

--- a/projects/components/src/skeleton/element.ts
+++ b/projects/components/src/skeleton/element.ts
@@ -1,0 +1,45 @@
+import { html, LitElement } from 'lit';
+import { property } from 'lit/decorators/property.js';
+import { baseStyles, attachInternals } from '@blueprintui/components/internals';
+import styles from './element.css' with { type: 'css' };
+
+/**
+ * ```typescript
+ * import '@blueprintui/components/include/skeleton.js';
+ * ```
+ *
+ * ```html
+ * <bp-skeleton></bp-skeleton>
+ * ```
+ *
+ * @summary Skeleton provides a placeholder representation of content before it loads
+ * @element bp-skeleton
+ * @since 2.9.0
+ * @cssprop --width - Width of the skeleton (default: 100%)
+ * @cssprop --height - Height of the skeleton (default: 1rem)
+ * @cssprop --background - Background color of the skeleton
+ * @cssprop --border-radius - Border radius (controlled by shape attribute)
+ */
+export class BpSkeleton extends LitElement {
+  /** Animation effect applied to the skeleton */
+  @property({ type: String, reflect: true }) accessor effect: 'pulse' | 'sheen';
+
+  /** Shape of the skeleton */
+  @property({ type: String, reflect: true }) accessor shape: 'circle';
+
+  static styles = [baseStyles, styles];
+
+  declare _internals: ElementInternals;
+
+  render() {
+    return html`<div part="internal"></div>`;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    attachInternals(this);
+    this._internals.role = 'presentation';
+    this._internals.ariaLive = 'polite';
+    this._internals.ariaLabel = 'Loading content';
+  }
+}

--- a/projects/components/src/skeleton/element.visual.ts
+++ b/projects/components/src/skeleton/element.visual.ts
@@ -1,0 +1,36 @@
+import { html } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { visualDiff } from '@web/test-runner-visual-regression';
+import { createVisualFixture, removeFixture } from '@blueprintui/test';
+import * as skeleton from './element.examples.js';
+import '@blueprintui/components/include/skeleton.js';
+
+describe('bp-skeleton', () => {
+  let fixture: HTMLElement;
+
+  /* eslint-disable lit/prefer-static-styles */
+  beforeEach(async () => {
+    fixture = await createVisualFixture(html`
+      <style>
+        bp-skeleton {
+          --animation-duration: 0s;
+        }
+      </style>
+      ${unsafeHTML(skeleton.example())} ${unsafeHTML(skeleton.effect())} ${unsafeHTML(skeleton.shape())}
+      ${unsafeHTML(skeleton.avatar())} ${unsafeHTML(skeleton.textLines())} ${unsafeHTML(skeleton.cardLayout())}
+    `);
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('light theme', async () => {
+    await visualDiff(fixture, 'skeleton/light.png');
+  });
+
+  it('dark theme', async () => {
+    document.documentElement.setAttribute('bp-theme', 'dark');
+    await visualDiff(fixture, 'skeleton/dark.png');
+  });
+});

--- a/projects/components/src/skeleton/index.ts
+++ b/projects/components/src/skeleton/index.ts
@@ -1,0 +1,1 @@
+export * from './element.js';

--- a/projects/docs/src/_layouts/base.11ty.js
+++ b/projects/docs/src/_layouts/base.11ty.js
@@ -116,6 +116,7 @@ export function render(data) {
               <bp-tree-item ${data.page.url === '/docs/components/rating.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/rating.html">Rating</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/search.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/search.html">Search</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/select.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/select.html">Select</a></bp-tree-item>
+              <bp-tree-item ${data.page.url === '/docs/components/skeleton.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/skeleton.html">Skeleton</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/stepper.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/stepper.html">Stepper</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/switch.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/switch.html">Switch</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/tabs.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/tabs.html">Tabs</a></bp-tree-item>

--- a/projects/docs/src/_pages/components/skeleton.11ty.js
+++ b/projects/docs/src/_pages/components/skeleton.11ty.js
@@ -1,0 +1,48 @@
+import schema from '../../../..//components/.drafter/schema.json' with { type: 'json' };
+import { getImport, getExample, getAPI, getElementSummary } from '../../_includes/utils/index.js';
+
+export const data = {
+  title: 'Skeleton',
+  schema: schema.find(c => c.name === 'skeleton')
+};
+
+export function render() {
+  return /* markdown */`
+${getElementSummary(data.schema, 'bp-skeleton')}
+
+${getExample(data.schema, 'example')}
+
+${getExample(data.schema, 'effect')}
+
+${getExample(data.schema, 'shape')}
+
+${getExample(data.schema, 'avatar')}
+
+${getExample(data.schema, 'text-lines')}
+
+${getExample(data.schema, 'card-layout')}
+
+${getExample(data.schema, 'image-layout')}
+
+${getExample(data.schema, 'custom-colors')}
+
+${getImport(data.schema)}
+
+## Accessibility
+- The skeleton component has a presentation role by default
+- The aria-live attribute is set to "polite" to announce loading state changes
+- Use skeletons to indicate that content is loading without disrupting the user's experience
+- Ensure that the skeleton matches the general structure and layout of the content it represents
+
+## Usage Guidelines
+- Use skeletons to represent loading states for various UI elements (text, images, cards, etc.)
+- Match the skeleton shape and size to the content it will eventually display
+- Use the \`pulse\` effect for subtle, ambient loading indicators
+- Use the \`sheen\` effect for more prominent loading states that draw attention
+- Use the \`none\` effect when you need static placeholder shapes
+- For circular content (avatars, profile pictures), use \`shape="circle"\` with equal width and height
+- Group multiple skeletons together to represent complex layouts during loading
+
+${getAPI(data.schema)}
+`;
+}


### PR DESCRIPTION
Implement bp-skeleton component with the following features:
- Two shapes: rect (rectangle) and circle
- Three animation effects: none, pulse, and sheen
- Customizable via CSS custom properties (--width, --height, --background, --border-radius)
- Accessibility support with presentation role and aria-live polite
- Comprehensive examples including avatars, text lines, card layouts, and image layouts
- Full test coverage (unit, visual, and performance tests)
- Complete documentation with usage guidelines

The skeleton component provides a placeholder representation of content before it loads, improving perceived performance and user experience.