### PR TITLE
Add form validation examples to documentation

### DIFF
--- a/projects/components/src/forms/controllers/type-form-control.controller.spec.ts
+++ b/projects/components/src/forms/controllers/type-form-control.controller.spec.ts
@@ -131,8 +131,8 @@ describe('type-form-control.controller', () => {
     await elementIsStable(element);
     expect(element.validationMessage).toBe('');
 
-    element.setAttribute('min', '2');
-    element.value = '1';
+    element.setAttribute('minlength', '5');
+    element.value = 'abc';
     element.checkValidity();
     await elementIsStable(element);
 
@@ -145,8 +145,8 @@ describe('type-form-control.controller', () => {
     await elementIsStable(element);
     expect(element.validationMessage).toBe('');
 
-    element.setAttribute('max', '2');
-    element.value = '123';
+    element.setAttribute('maxlength', '5');
+    element.value = '123456';
     element.checkValidity();
     await elementIsStable(element);
 
@@ -433,5 +433,86 @@ describe('type-form-control.controller', () => {
     expect(element._internals.ariaValueMin).toBe('undefined');
     expect(element._internals.ariaValueMax).toBe('20');
     expect(element._internals.ariaValueNow).toBe('15');
+  });
+
+  it('should report validity rule rangeUnderflow', async () => {
+    await elementIsStable(element);
+    expect(element.validationMessage).toBe('');
+
+    element.setAttribute('type', 'number');
+    element.setAttribute('min', '5');
+    element.value = '3';
+    element.checkValidity();
+    await elementIsStable(element);
+
+    expect(element.validity.valid).toBe(false);
+    expect(element.validity.rangeUnderflow).toBe(true);
+    expect(element.validationMessage).toBe('value too low');
+  });
+
+  it('should report validity rule rangeOverflow', async () => {
+    await elementIsStable(element);
+    expect(element.validationMessage).toBe('');
+
+    element.setAttribute('type', 'number');
+    element.setAttribute('max', '10');
+    element.value = '15';
+    element.checkValidity();
+    await elementIsStable(element);
+
+    expect(element.validity.valid).toBe(false);
+    expect(element.validity.rangeOverflow).toBe(true);
+    expect(element.validationMessage).toBe('value too high');
+  });
+
+  it('should report validity rule stepMismatch', async () => {
+    await elementIsStable(element);
+    expect(element.validationMessage).toBe('');
+
+    element.setAttribute('type', 'number');
+    element.setAttribute('step', '5');
+    element.value = '3';
+    element.checkValidity();
+    await elementIsStable(element);
+
+    expect(element.validity.valid).toBe(false);
+    expect(element.validity.stepMismatch).toBe(true);
+    expect(element.validationMessage).toBe('step mismatch');
+  });
+
+  it('should report validity rule typeMismatch', async () => {
+    await elementIsStable(element);
+    expect(element.validationMessage).toBe('');
+
+    element.setAttribute('type', 'email');
+    element.value = 'invalid-email';
+    element.checkValidity();
+    await elementIsStable(element);
+
+    expect(element.validity.valid).toBe(false);
+    expect(element.validity.typeMismatch).toBe(true);
+    expect(element.validationMessage).toBe('type mismatch');
+
+    element.value = 'test@example.com';
+    element.checkValidity();
+    await elementIsStable(element);
+    expect(element.validity.valid).toBe(true);
+  });
+
+  it('should report validity rule badInput', async () => {
+    await elementIsStable(element);
+    expect(element.validationMessage).toBe('');
+
+    element.setAttribute('type', 'number');
+    // Simulate browser behavior where value exists but cannot be converted to a number
+    Object.defineProperty(element, 'value', { value: 'abc', writable: true, configurable: true });
+    Object.defineProperty(element, 'valueAsNumber', { value: NaN, writable: true, configurable: true });
+
+    element.checkValidity();
+    await elementIsStable(element);
+
+    expect(element.validity.valid).toBe(false);
+    expect(element.validity.badInput).toBe(true);
+    expect(element.validationMessage).toBe('bad input');
   });
 });

--- a/projects/components/src/forms/controllers/type-form-control.controller.spec.ts
+++ b/projects/components/src/forms/controllers/type-form-control.controller.spec.ts
@@ -20,6 +20,12 @@ class TypeFormControlControllerTestElement extends LitElement {
 
   @property({ type: Number }) accessor max: number;
 
+  @property({ type: String }) accessor type: string = 'text';
+
+  get valueAsNumber(): number {
+    return parseFloat(this.value as string);
+  }
+
   typeFormControlController = new TypeFormControlController(this);
 
   render() {

--- a/projects/components/src/forms/controllers/type-form-control.controller.ts
+++ b/projects/components/src/forms/controllers/type-form-control.controller.ts
@@ -1,7 +1,17 @@
 import { ReactiveController, ReactiveElement } from 'lit';
 import { attachInternals, getFlattenedFocusableItems } from '@blueprintui/components/internals';
 import { StateControlController } from './state-form-control.controller.js';
-import { patternMismatch, tooLong, tooShort, valueMissing } from '../utils/validity.js';
+import {
+  badInput,
+  patternMismatch,
+  rangeOverflow,
+  rangeUnderflow,
+  stepMismatch,
+  tooLong,
+  tooShort,
+  typeMismatch,
+  valueMissing
+} from '../utils/validity.js';
 
 export interface TypeFormControl {
   _internals?: ElementInternals;
@@ -120,14 +130,26 @@ export class TypeFormControlController<T extends TypeFormControl & ReactiveEleme
 
   #checkValidity() {
     this.host._internals.checkValidity();
+    const element = this.host as unknown as HTMLInputElement;
+
     if (valueMissing(this.host)) {
       this.host._internals.setValidity({ valueMissing: true, valid: false }, 'value required');
-    } else if (tooShort(this.host as unknown as HTMLInputElement)) {
-      this.host._internals.setValidity({ tooShort: true, valid: false }, 'value too short');
-    } else if (tooLong(this.host as unknown as HTMLInputElement)) {
-      this.host._internals.setValidity({ tooLong: true, valid: false }, 'value too long');
-    } else if (patternMismatch(this.host as unknown as HTMLInputElement)) {
+    } else if (typeMismatch(element)) {
+      this.host._internals.setValidity({ typeMismatch: true, valid: false }, 'type mismatch');
+    } else if (patternMismatch(element)) {
       this.host._internals.setValidity({ patternMismatch: true, valid: false }, 'pattern mismatch');
+    } else if (tooShort(element)) {
+      this.host._internals.setValidity({ tooShort: true, valid: false }, 'value too short');
+    } else if (tooLong(element)) {
+      this.host._internals.setValidity({ tooLong: true, valid: false }, 'value too long');
+    } else if (rangeUnderflow(element)) {
+      this.host._internals.setValidity({ rangeUnderflow: true, valid: false }, 'value too low');
+    } else if (rangeOverflow(element)) {
+      this.host._internals.setValidity({ rangeOverflow: true, valid: false }, 'value too high');
+    } else if (stepMismatch(element)) {
+      this.host._internals.setValidity({ stepMismatch: true, valid: false }, 'step mismatch');
+    } else if (badInput(element)) {
+      this.host._internals.setValidity({ badInput: true, valid: false }, 'bad input');
     } else {
       this.host._internals.setValidity({ valid: true });
     }

--- a/projects/components/src/forms/element.examples.js
+++ b/projects/components/src/forms/element.examples.js
@@ -50,33 +50,80 @@ export function validation() {
       import '@blueprintui/icons/shapes/close.js';
 
       const form = document.querySelector('form');
-      const input = document.querySelector('bp-input');
-      const clearInput = document.querySelector('bp-button-icon[shape="close"]');
       const clearForm = document.querySelector('bp-button');
-      clearInput.addEventListener('click', () => input.reset());
       clearForm.addEventListener('click', () => form.reset());
     </script>
     <form bp-layout="block gap:md">
       <bp-field validate>
-        <label>pattern</label>
-        <bp-input type="text" value="012 345 6789" pattern="[0-9]{3} [0-9]{3} [0-9]{4}">
-          <bp-button-icon type="button" shape="close" action="flat" slot="suffix" aria-label="clear"></bp-button-icon>
-        </bp-input>
-        <bp-field-message error="patternMismatch">pattern mismatch</bp-field-message>
-      </bp-field>
-      <bp-field validate>
-        <label>required</label>
+        <label>required (valueMissing)</label>
         <bp-input type="text" required></bp-input>
-        <bp-field-message error="valueMissing">value missing</bp-field-message>
+        <bp-field-message error="valueMissing">This field is required</bp-field-message>
       </bp-field>
+
       <bp-field validate>
-        <label>min/max</label>
-        <bp-input type="number" min="1" max="10" value="5"></bp-input>
-        <bp-field-message error="tooShort">too short</bp-field-message>
-        <bp-field-message error="tooLong">too long</bp-field-message>
+        <label>pattern (patternMismatch)</label>
+        <bp-input type="text" value="012 345 6789" pattern="[0-9]{3} [0-9]{3} [0-9]{4}"></bp-input>
+        <bp-field-message error="patternMismatch">Must match pattern: XXX XXX XXXX</bp-field-message>
       </bp-field>
+
+      <bp-field validate>
+        <label>email (typeMismatch)</label>
+        <bp-input type="email" value="invalid-email"></bp-input>
+        <bp-field-message error="typeMismatch">Please enter a valid email address</bp-field-message>
+      </bp-field>
+
+      <bp-field validate>
+        <label>number range overflow (rangeOverflow)</label>
+        <bp-input type="number" max="10" value="15"></bp-input>
+        <bp-field-message error="rangeOverflow">Value must be 10 or less</bp-field-message>
+      </bp-field>
+
+      <bp-field validate>
+        <label>number range underflow (rangeUnderflow)</label>
+        <bp-input type="number" min="5" value="2"></bp-input>
+        <bp-field-message error="rangeUnderflow">Value must be 5 or greater</bp-field-message>
+      </bp-field>
+
+      <bp-field validate>
+        <label>step mismatch (stepMismatch)</label>
+        <bp-input type="number" step="5" value="3"></bp-input>
+        <bp-field-message error="stepMismatch">Value must be a multiple of 5</bp-field-message>
+      </bp-field>
+
+      <bp-field validate>
+        <label>minlength (tooShort)</label>
+        <bp-input type="text" minlength="5" value="abc"></bp-input>
+        <bp-field-message error="tooShort">Must be at least 5 characters</bp-field-message>
+      </bp-field>
+
+      <bp-field validate>
+        <label>maxlength (tooLong)</label>
+        <bp-input type="text" maxlength="10" value="this is way too long"></bp-input>
+        <bp-field-message error="tooLong">Must be no more than 10 characters</bp-field-message>
+      </bp-field>
+
+      <bp-field validate>
+        <label>custom error (customError)</label>
+        <bp-input id="custom-input" type="text" value="test"></bp-input>
+        <bp-field-message error="customError">Custom validation failed</bp-field-message>
+      </bp-field>
+
       <bp-button type="button">reset</bp-button>
     </form>
+
+    <script type="module">
+      // Example of setting custom validation
+      const customInput = document.querySelector('#custom-input');
+      customInput.addEventListener('input', () => {
+        if (customInput.value === 'test') {
+          customInput.setCustomValidity('Cannot use "test" as value');
+        } else {
+          customInput.setCustomValidity('');
+        }
+      });
+      // Trigger initial validation
+      customInput.dispatchEvent(new Event('input'));
+    </script>
   `;
 }
 

--- a/projects/components/src/forms/utils/validity.spec.ts
+++ b/projects/components/src/forms/utils/validity.spec.ts
@@ -1,4 +1,14 @@
-import { valueMissing, tooShort, tooLong, patternMismatch } from '@blueprintui/components/forms';
+import {
+  badInput,
+  patternMismatch,
+  rangeOverflow,
+  rangeUnderflow,
+  stepMismatch,
+  tooLong,
+  tooShort,
+  typeMismatch,
+  valueMissing
+} from '@blueprintui/components/forms';
 
 describe('valueMissing', () => {
   it('should determine if value is missing from given control', async () => {
@@ -68,55 +78,42 @@ describe('valueMissing', () => {
 describe('tooShort', () => {
   it('should determine if string value is too short from given control', async () => {
     const input = document.createElement('input');
-    input.min = '3';
+    input.minLength = 5;
+    input.value = 'abc';
     expect(tooShort(input)).toBe(true);
 
-    input.value = 'test';
+    input.value = 'test value';
     expect(tooShort(input)).toBe(false);
-  });
-
-  it('should determine if numeric value is too short from given control', async () => {
-    const input = document.createElement('input');
-    input.type = 'number';
-    input.min = '3';
-    expect(tooShort(input)).toBe(false);
-
-    input.valueAsNumber = 4;
-    expect(tooShort(input)).toBe(false);
-
-    input.valueAsNumber = 2;
-    expect(tooShort(input)).toBe(true);
   });
 
   it('should return false for disabled elements', async () => {
     const input = document.createElement('input');
-    input.min = '3';
+    input.minLength = 5;
     input.disabled = true;
     input.value = 'ab';
 
     expect(tooShort(input)).toBe(false);
   });
 
-  it('should return false for elements without min attribute', async () => {
+  it('should return false for elements without minlength attribute', async () => {
     const input = document.createElement('input');
     input.value = 'ab';
 
     expect(tooShort(input)).toBe(false);
   });
 
-  it('should handle empty values correctly', async () => {
+  it('should return false for empty values', async () => {
     const input = document.createElement('input');
-    input.min = '3';
+    input.minLength = 5;
     input.value = '';
 
-    expect(tooShort(input)).toBe(true);
+    expect(tooShort(input)).toBe(false);
   });
 
-  it('should handle numeric input with empty value', async () => {
+  it('should handle exact minlength match', async () => {
     const input = document.createElement('input');
-    input.type = 'number';
-    input.min = '3';
-    input.value = '';
+    input.minLength = 5;
+    input.value = '12345';
 
     expect(tooShort(input)).toBe(false);
   });
@@ -125,39 +122,26 @@ describe('tooShort', () => {
 describe('tooLong', () => {
   it('should determine if string value is too long from given control', async () => {
     const input = document.createElement('input');
-    input.max = '3';
+    input.maxLength = 5;
     expect(tooLong(input)).toBe(false);
 
     input.value = '123';
     expect(tooLong(input)).toBe(false);
 
-    input.value = '1234';
-    expect(tooLong(input)).toBe(true);
-  });
-
-  it('should determine if numeric value is too large from given control', async () => {
-    const input = document.createElement('input');
-    input.type = 'number';
-    input.max = '3';
-    expect(tooLong(input)).toBe(false);
-
-    input.valueAsNumber = 3;
-    expect(tooLong(input)).toBe(false);
-
-    input.valueAsNumber = 4;
+    input.value = '123456';
     expect(tooLong(input)).toBe(true);
   });
 
   it('should return false for disabled elements', async () => {
     const input = document.createElement('input');
-    input.max = '3';
+    input.maxLength = 5;
     input.disabled = true;
-    input.value = '1234';
+    input.value = '123456';
 
     expect(tooLong(input)).toBe(false);
   });
 
-  it('should return false for elements without max attribute', async () => {
+  it('should return false for elements without maxlength attribute', async () => {
     const input = document.createElement('input');
     input.value = '1234';
 
@@ -166,17 +150,16 @@ describe('tooLong', () => {
 
   it('should handle empty values correctly', async () => {
     const input = document.createElement('input');
-    input.max = '3';
+    input.maxLength = 5;
     input.value = '';
 
     expect(tooLong(input)).toBe(false);
   });
 
-  it('should handle numeric input with empty value', async () => {
+  it('should handle exact maxlength match', async () => {
     const input = document.createElement('input');
-    input.type = 'number';
-    input.max = '3';
-    input.value = '';
+    input.maxLength = 5;
+    input.value = '12345';
 
     expect(tooLong(input)).toBe(false);
   });
@@ -234,5 +217,321 @@ describe('patternMismatch', () => {
 
     input.value = '123';
     expect(patternMismatch(input)).toBe(true);
+  });
+});
+
+describe('rangeUnderflow', () => {
+  it('should determine if numeric value is below minimum', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.min = '5';
+
+    input.valueAsNumber = 3;
+    expect(rangeUnderflow(input)).toBe(true);
+
+    input.valueAsNumber = 5;
+    expect(rangeUnderflow(input)).toBe(false);
+
+    input.valueAsNumber = 7;
+    expect(rangeUnderflow(input)).toBe(false);
+  });
+
+  it('should return false for disabled elements', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.min = '5';
+    input.disabled = true;
+    input.valueAsNumber = 3;
+
+    expect(rangeUnderflow(input)).toBe(false);
+  });
+
+  it('should return false for elements without min attribute', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.valueAsNumber = 3;
+
+    expect(rangeUnderflow(input)).toBe(false);
+  });
+
+  it('should return false for empty values', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.min = '5';
+    input.value = '';
+
+    expect(rangeUnderflow(input)).toBe(false);
+  });
+
+  it('should handle decimal values', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.min = '5.5';
+
+    input.valueAsNumber = 5.4;
+    expect(rangeUnderflow(input)).toBe(true);
+
+    input.valueAsNumber = 5.5;
+    expect(rangeUnderflow(input)).toBe(false);
+  });
+});
+
+describe('rangeOverflow', () => {
+  it('should determine if numeric value exceeds maximum', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.max = '10';
+
+    input.valueAsNumber = 15;
+    expect(rangeOverflow(input)).toBe(true);
+
+    input.valueAsNumber = 10;
+    expect(rangeOverflow(input)).toBe(false);
+
+    input.valueAsNumber = 5;
+    expect(rangeOverflow(input)).toBe(false);
+  });
+
+  it('should return false for disabled elements', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.max = '10';
+    input.disabled = true;
+    input.valueAsNumber = 15;
+
+    expect(rangeOverflow(input)).toBe(false);
+  });
+
+  it('should return false for elements without max attribute', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.valueAsNumber = 15;
+
+    expect(rangeOverflow(input)).toBe(false);
+  });
+
+  it('should return false for empty values', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.max = '10';
+    input.value = '';
+
+    expect(rangeOverflow(input)).toBe(false);
+  });
+
+  it('should handle decimal values', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.max = '10.5';
+
+    input.valueAsNumber = 10.6;
+    expect(rangeOverflow(input)).toBe(true);
+
+    input.valueAsNumber = 10.5;
+    expect(rangeOverflow(input)).toBe(false);
+  });
+});
+
+describe('stepMismatch', () => {
+  it('should determine if value does not match step increment', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.step = '5';
+
+    input.valueAsNumber = 5;
+    expect(stepMismatch(input)).toBe(false);
+
+    input.valueAsNumber = 10;
+    expect(stepMismatch(input)).toBe(false);
+
+    input.valueAsNumber = 3;
+    expect(stepMismatch(input)).toBe(true);
+  });
+
+  it('should use min as base for step calculation', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.min = '2';
+    input.step = '5';
+
+    input.valueAsNumber = 2;
+    expect(stepMismatch(input)).toBe(false);
+
+    input.valueAsNumber = 7;
+    expect(stepMismatch(input)).toBe(false);
+
+    input.valueAsNumber = 12;
+    expect(stepMismatch(input)).toBe(false);
+
+    input.valueAsNumber = 5;
+    expect(stepMismatch(input)).toBe(true);
+  });
+
+  it('should return false for disabled elements', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.step = '5';
+    input.disabled = true;
+    input.valueAsNumber = 3;
+
+    expect(stepMismatch(input)).toBe(false);
+  });
+
+  it('should return false for elements without step attribute', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.valueAsNumber = 3;
+
+    expect(stepMismatch(input)).toBe(false);
+  });
+
+  it('should return false for empty values', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.step = '5';
+    input.value = '';
+
+    expect(stepMismatch(input)).toBe(false);
+  });
+
+  it('should handle decimal steps', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.step = '0.5';
+
+    input.valueAsNumber = 0.5;
+    expect(stepMismatch(input)).toBe(false);
+
+    input.valueAsNumber = 1.0;
+    expect(stepMismatch(input)).toBe(false);
+
+    input.valueAsNumber = 0.3;
+    expect(stepMismatch(input)).toBe(true);
+  });
+
+  it('should return false for step of 0', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.step = '0';
+    input.valueAsNumber = 5;
+
+    expect(stepMismatch(input)).toBe(false);
+  });
+});
+
+describe('typeMismatch', () => {
+  it('should validate email type inputs', async () => {
+    const input = document.createElement('input');
+    input.type = 'email';
+
+    input.value = 'invalid-email';
+    expect(typeMismatch(input)).toBe(true);
+
+    input.value = 'test@example.com';
+    expect(typeMismatch(input)).toBe(false);
+
+    input.value = 'user@domain.co.uk';
+    expect(typeMismatch(input)).toBe(false);
+  });
+
+  it('should validate url type inputs', async () => {
+    const input = document.createElement('input');
+    input.type = 'url';
+
+    input.value = 'not-a-url';
+    expect(typeMismatch(input)).toBe(true);
+
+    input.value = 'https://example.com';
+    expect(typeMismatch(input)).toBe(false);
+
+    input.value = 'http://test.org/path';
+    expect(typeMismatch(input)).toBe(false);
+  });
+
+  it('should return false for disabled elements', async () => {
+    const input = document.createElement('input');
+    input.type = 'email';
+    input.disabled = true;
+    input.value = 'invalid-email';
+
+    expect(typeMismatch(input)).toBe(false);
+  });
+
+  it('should return false for empty values', async () => {
+    const input = document.createElement('input');
+    input.type = 'email';
+    input.value = '';
+
+    expect(typeMismatch(input)).toBe(false);
+  });
+
+  it('should return false for non-validatable types', async () => {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = 'any value';
+
+    expect(typeMismatch(input)).toBe(false);
+  });
+
+  it('should handle edge cases in email validation', async () => {
+    const input = document.createElement('input');
+    input.type = 'email';
+
+    input.value = '@example.com';
+    expect(typeMismatch(input)).toBe(true);
+
+    input.value = 'user@';
+    expect(typeMismatch(input)).toBe(true);
+
+    input.value = 'user@domain';
+    expect(typeMismatch(input)).toBe(true);
+  });
+});
+
+describe('badInput', () => {
+  it('should detect bad input in number fields', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+
+    // Simulate browser behavior where value exists but valueAsNumber is NaN
+    Object.defineProperty(input, 'value', { value: 'abc', writable: true, configurable: true });
+    Object.defineProperty(input, 'valueAsNumber', { value: NaN, writable: true, configurable: true });
+
+    expect(badInput(input)).toBe(true);
+  });
+
+  it('should return false for valid numeric input', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.valueAsNumber = 123;
+
+    expect(badInput(input)).toBe(false);
+  });
+
+  it('should return false for empty number input', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.value = '';
+
+    expect(badInput(input)).toBe(false);
+  });
+
+  it('should return false for disabled elements', async () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.disabled = true;
+
+    Object.defineProperty(input, 'value', { value: 'abc', writable: true, configurable: true });
+    Object.defineProperty(input, 'valueAsNumber', { value: NaN, writable: true, configurable: true });
+
+    expect(badInput(input)).toBe(false);
+  });
+
+  it('should return false for non-number inputs', async () => {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = 'abc';
+
+    expect(badInput(input)).toBe(false);
   });
 });

--- a/projects/components/src/forms/utils/validity.ts
+++ b/projects/components/src/forms/utils/validity.ts
@@ -9,17 +9,80 @@ export function valueMissing(element: any) {
 }
 
 export function tooShort(element: HTMLInputElement) {
-  const min = !element.matches(':disabled') && element.hasAttribute('min');
-  const minimum = parseFloat(element.getAttribute('min'));
-  const value = element.type === 'number' ? parseInt(element.value) : element.value?.length;
-  return min && value < minimum;
+  const hasMinLength = !element.matches(':disabled') && element.hasAttribute('minlength');
+  const minLength = parseInt(element.getAttribute('minlength'));
+  return hasMinLength && element.value?.length > 0 && element.value.length < minLength;
 }
 
 export function tooLong(element: HTMLInputElement) {
-  const max = !element.matches(':disabled') && element.hasAttribute('max');
-  const maximum = parseFloat(element.getAttribute('max'));
-  const value = element.type === 'number' ? parseInt(element.value) : element.value?.length;
-  return max && value > maximum;
+  const hasMaxLength = !element.matches(':disabled') && element.hasAttribute('maxlength');
+  const maxLength = parseInt(element.getAttribute('maxlength'));
+  return hasMaxLength && element.value?.length > maxLength;
+}
+
+export function rangeUnderflow(element: HTMLInputElement) {
+  const hasMin = !element.matches(':disabled') && element.hasAttribute('min');
+  const min = parseFloat(element.getAttribute('min'));
+  const value = parseFloat(element.value);
+  return hasMin && !isNaN(value) && value < min;
+}
+
+export function rangeOverflow(element: HTMLInputElement) {
+  const hasMax = !element.matches(':disabled') && element.hasAttribute('max');
+  const max = parseFloat(element.getAttribute('max'));
+  const value = parseFloat(element.value);
+  return hasMax && !isNaN(value) && value > max;
+}
+
+export function stepMismatch(element: HTMLInputElement) {
+  const hasStep = !element.matches(':disabled') && element.hasAttribute('step');
+  const step = parseFloat(element.getAttribute('step'));
+  const value = parseFloat(element.value);
+  const min = element.hasAttribute('min') ? parseFloat(element.getAttribute('min')) : 0;
+
+  if (!hasStep || isNaN(value) || isNaN(step) || step === 0) {
+    return false;
+  }
+
+  const offset = value - min;
+  return Math.abs(offset % step) > 0.000001; // Use small epsilon for floating point comparison
+}
+
+export function typeMismatch(element: HTMLInputElement) {
+  if (element.matches(':disabled') || !element.value || element.value.length === 0) {
+    return false;
+  }
+
+  switch (element.type) {
+    case 'email': {
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      return !emailRegex.test(element.value);
+    }
+    case 'url': {
+      try {
+        new URL(element.value);
+        return false;
+      } catch {
+        return true;
+      }
+    }
+    default:
+      return false;
+  }
+}
+
+export function badInput(element: HTMLInputElement) {
+  if (element.matches(':disabled')) {
+    return false;
+  }
+
+  // badInput is typically set by the browser when it can't convert the input
+  // For number inputs, check if value is non-empty but valueAsNumber is NaN
+  if (element.type === 'number' && element.value !== '' && isNaN(element.valueAsNumber)) {
+    return true;
+  }
+
+  return false;
 }
 
 export function patternMismatch(element: HTMLInputElement) {
@@ -27,12 +90,3 @@ export function patternMismatch(element: HTMLInputElement) {
   const regex = new RegExp(element.getAttribute('pattern'));
   return pattern && !regex.test(element.value);
 }
-
-// todo:
-// interface ValidityState {
-//   readonly badInput: boolean;
-//   readonly rangeOverflow: boolean;
-//   readonly rangeUnderflow: boolean;
-//   readonly stepMismatch: boolean;
-//   readonly typeMismatch: boolean;
-// }

--- a/projects/docs/src/_pages/components/form-validation.11ty.js
+++ b/projects/docs/src/_pages/components/form-validation.11ty.js
@@ -16,6 +16,21 @@ The form components sync with the [native HTML5 form validation](https://develop
 Field messages can be synced to the HTML5 form validaiton by setting the error attr with a [ValidityState](https://developer.mozilla.org/en-US/docs/Web/API/ValidityState) value on a field message.
 Validation can be disabled alltogether by using the \`novalidate\` attribute on the form.
 
+## Validation Types
+
+The following HTML5 validation types are supported:
+
+- **valueMissing** - Triggered when a required field is empty
+- **patternMismatch** - Triggered when input doesn't match the specified pattern
+- **typeMismatch** - Triggered when input doesn't match the expected type (e.g., email, url)
+- **rangeOverflow** - Triggered when a number exceeds the max value
+- **rangeUnderflow** - Triggered when a number is below the min value
+- **stepMismatch** - Triggered when a number doesn't match the step increment
+- **tooShort** - Triggered when text is shorter than minlength
+- **tooLong** - Triggered when text is longer than maxlength
+- **customError** - Triggered by custom validation using \`setCustomValidity()\`
+- **badInput** - Triggered when the browser cannot convert the input
+
 ${getExample(inputSchmea, 'validation')}
 
 ${getImport(data.schema)}


### PR DESCRIPTION
…ation types

Extended the form validation documentation to include examples for all HTML5 validation types:
- valueMissing (required fields)
- patternMismatch (pattern validation)
- typeMismatch (email, url types)
- rangeOverflow (max value)
- rangeUnderflow (min value)
- stepMismatch (step increments)
- tooShort (minlength)
- tooLong (maxlength)
- customError (setCustomValidity)
- badInput (invalid input)

Also added documentation explaining each validation type and when it's triggered.