### PR TITLE
Add bp-format-relative-time component

### DIFF
--- a/projects/components/custom-elements.lock.json
+++ b/projects/components/custom-elements.lock.json
@@ -5615,7 +5615,7 @@
               }
             },
             {
-              "description": "slot for suffic text or icons",
+              "description": "slot for suffiix text or icons",
               "name": "suffix",
               "inheritedFrom": {
                 "name": "BpInput",
@@ -8371,6 +8371,207 @@
     },
     {
       "kind": "javascript-module",
+      "path": "/format-bytes/element.css",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "/format-bytes/element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "```typescript\nimport '@blueprintui/components/include/format-bytes.js';\n```\n\n```html\n<bp-format-bytes></bp-format-bytes>\n```",
+          "name": "BpFormatBytes",
+          "members": [
+            {
+              "kind": "field",
+              "name": "display",
+              "type": {
+                "text": "'decimal' | 'binary'"
+              },
+              "default": "'decimal'",
+              "description": "determines the base unit system: 'decimal' (1000-based) or 'binary' (1024-based)",
+              "attribute": "display"
+            },
+            {
+              "kind": "field",
+              "name": "unit",
+              "type": {
+                "text": "'b' | 'kb' | 'mb' | 'gb' | 'tb' | 'pb'"
+              },
+              "description": "force a specific unit instead of auto-detection (b, kb, mb, gb, tb, pb)",
+              "attribute": "unit"
+            },
+            {
+              "kind": "field",
+              "name": "unitDisplay",
+              "type": {
+                "text": "'long' | 'short'"
+              },
+              "default": "'short'",
+              "description": "determines how units are displayed: 'short' (kb), 'long' (kilobytes)",
+              "attribute": "unit-display"
+            },
+            {
+              "kind": "field",
+              "name": "locales",
+              "type": {
+                "text": "string[]"
+              },
+              "description": "locales to use for number formatting",
+              "attribute": "locales"
+            },
+            {
+              "kind": "field",
+              "name": "minimumFractionDigits",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "description": "minimum number of fraction digits to display",
+              "attribute": "minimum-fraction-digits"
+            },
+            {
+              "kind": "field",
+              "name": "maximumFractionDigits",
+              "type": {
+                "text": "number"
+              },
+              "default": "2",
+              "description": "maximum number of fraction digits to display",
+              "attribute": "maximum-fraction-digits"
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "attribute": "value"
+            },
+            {
+              "kind": "field",
+              "name": "#divisor",
+              "privacy": "private",
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "#units",
+              "privacy": "private",
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "#formattedValue",
+              "privacy": "private",
+              "readonly": true
+            }
+          ],
+          "attributes": [
+            {
+              "name": "display",
+              "type": {
+                "text": "'decimal' | 'binary'"
+              },
+              "default": "'decimal'",
+              "description": "determines the base unit system: 'decimal' (1000-based) or 'binary' (1024-based)",
+              "fieldName": "display"
+            },
+            {
+              "name": "unit",
+              "type": {
+                "text": "'b' | 'kb' | 'mb' | 'gb' | 'tb' | 'pb'"
+              },
+              "description": "force a specific unit instead of auto-detection (b, kb, mb, gb, tb, pb)",
+              "fieldName": "unit"
+            },
+            {
+              "name": "unit-display",
+              "type": {
+                "text": "'long' | 'short'"
+              },
+              "default": "'short'",
+              "description": "determines how units are displayed: 'short' (kb), 'long' (kilobytes)",
+              "fieldName": "unitDisplay"
+            },
+            {
+              "name": "locales",
+              "type": {
+                "text": "string[]"
+              },
+              "description": "locales to use for number formatting",
+              "fieldName": "locales"
+            },
+            {
+              "name": "minimum-fraction-digits",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "description": "minimum number of fraction digits to display",
+              "fieldName": "minimumFractionDigits"
+            },
+            {
+              "name": "maximum-fraction-digits",
+              "type": {
+                "text": "number"
+              },
+              "default": "2",
+              "description": "maximum number of fraction digits to display",
+              "fieldName": "maximumFractionDigits"
+            },
+            {
+              "name": "value",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "fieldName": "value"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "bp-format-bytes",
+          "customElement": true,
+          "summary": "The format-bytes component is used to display byte values in a human-readable format with automatic unit conversion (b, kb, mb, gb, tb, pb).",
+          "metadata": {
+            "since": "2.9.0"
+          }
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "BpFormatBytes",
+          "declaration": {
+            "name": "BpFormatBytes",
+            "module": "/format-bytes/element.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "/format-bytes/index.js",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "package": "./element.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "/format-datetime/element.css",
       "declarations": [],
       "exports": []
@@ -8819,6 +9020,552 @@
     {
       "kind": "javascript-module",
       "path": "/format-number/index.js",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "package": "./element.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "/format-relative-time/element.css",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "/format-relative-time/element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "```typescript\nimport '@blueprintui/components/include/format-relative-time.js';\n```\n\n```html\n<bp-format-relative-time>2024-11-16T10:30:00Z</bp-format-relative-time>\n```",
+          "name": "BpFormatRelativeTime",
+          "members": [
+            {
+              "kind": "field",
+              "name": "numeric",
+              "type": {
+                "text": "'always' | 'auto'"
+              },
+              "default": "'auto'",
+              "description": "determines how to format the time: 'auto' shows \"yesterday\" vs \"1 day ago\"",
+              "attribute": "numeric"
+            },
+            {
+              "kind": "field",
+              "name": "formatStyle",
+              "type": {
+                "text": "'long' | 'short' | 'narrow'"
+              },
+              "default": "'long'",
+              "description": "determines the formatting style: 'long', 'short', or 'narrow'",
+              "attribute": "format-style"
+            },
+            {
+              "kind": "field",
+              "name": "unit",
+              "type": {
+                "text": "'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year' | 'auto'"
+              },
+              "default": "'auto'",
+              "description": "the time unit to use, or 'auto' to automatically select the best unit",
+              "attribute": "unit"
+            },
+            {
+              "kind": "field",
+              "name": "sync",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "auto-update the displayed time at appropriate intervals",
+              "attribute": "sync"
+            },
+            {
+              "kind": "field",
+              "name": "locale",
+              "type": {
+                "text": "string"
+              },
+              "description": "locale to use for formatting",
+              "attribute": "locale"
+            },
+            {
+              "kind": "field",
+              "name": "_value",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "private",
+              "default": "''"
+            },
+            {
+              "kind": "field",
+              "name": "_now",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "_syncInterval",
+              "type": {
+                "text": "number | null"
+              },
+              "privacy": "private",
+              "default": "null"
+            },
+            {
+              "kind": "field",
+              "name": "#relativeTime",
+              "privacy": "private",
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "#updateInterval",
+              "privacy": "private",
+              "readonly": true
+            },
+            {
+              "kind": "method",
+              "name": "#setupSync",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#clearSync",
+              "privacy": "private"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "numeric",
+              "type": {
+                "text": "'always' | 'auto'"
+              },
+              "default": "'auto'",
+              "description": "determines how to format the time: 'auto' shows \"yesterday\" vs \"1 day ago\"",
+              "fieldName": "numeric"
+            },
+            {
+              "name": "format-style",
+              "type": {
+                "text": "'long' | 'short' | 'narrow'"
+              },
+              "default": "'long'",
+              "description": "determines the formatting style: 'long', 'short', or 'narrow'",
+              "fieldName": "formatStyle"
+            },
+            {
+              "name": "unit",
+              "type": {
+                "text": "'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year' | 'auto'"
+              },
+              "default": "'auto'",
+              "description": "the time unit to use, or 'auto' to automatically select the best unit",
+              "fieldName": "unit"
+            },
+            {
+              "name": "sync",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "auto-update the displayed time at appropriate intervals",
+              "fieldName": "sync"
+            },
+            {
+              "name": "locale",
+              "type": {
+                "text": "string"
+              },
+              "description": "locale to use for formatting",
+              "fieldName": "locale"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "bp-format-relative-time",
+          "customElement": true,
+          "summary": "The format-relative-time component displays relative time (e.g., \"2 hours ago\", \"in 3 days\") using the Intl.RelativeTimeFormat API.",
+          "metadata": {
+            "since": "2.10.0"
+          }
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "BpFormatRelativeTime",
+          "declaration": {
+            "name": "BpFormatRelativeTime",
+            "module": "/format-relative-time/element.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "/format-relative-time/element.visual.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "/format-relative-time/index.js",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "*",
+          "declaration": {
+            "name": "*",
+            "package": "./element.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "/format-token/element.css",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "/format-token/element.js",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "```typescript\nimport '@blueprintui/components/include/format-token.js';\n```\n\n```html\n<bp-format-token format=\"word-piece\">Hello world!</bp-format-token>\n```",
+          "name": "BpFormatToken",
+          "cssProperties": [
+            {
+              "name": "--padding"
+            },
+            {
+              "name": "--border-radius"
+            },
+            {
+              "name": "--border"
+            },
+            {
+              "name": "--font-family"
+            },
+            {
+              "name": "--line-height"
+            },
+            {
+              "name": "--gap"
+            }
+          ],
+          "slots": [
+            {
+              "description": "Provide text content to be tokenized",
+              "name": ""
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "format",
+              "type": {
+                "text": "| 'bpe'\n    | 'word-piece'\n    | 'sentence-piece'\n    | 'llama'\n    | 'character'\n    | 'whitespace'"
+              },
+              "default": "'bpe'",
+              "description": "Tokenization format/strategy to use",
+              "attribute": "format",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "_text",
+              "type": {
+                "text": "string"
+              },
+              "privacy": "private",
+              "default": "''"
+            },
+            {
+              "kind": "field",
+              "name": "tokens",
+              "type": {
+                "text": "string[]"
+              },
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "#tokens",
+              "privacy": "private",
+              "type": {
+                "text": "string[]"
+              },
+              "default": "[]"
+            },
+            {
+              "kind": "field",
+              "name": "#colors",
+              "privacy": "private",
+              "type": {
+                "text": "array"
+              },
+              "default": "[ 'var(--bp-color-red-100)', 'var(--bp-color-blue-100)', 'var(--bp-color-green-100)', 'var(--bp-color-yellow-100)', 'var(--bp-color-violet-100)' ]"
+            },
+            {
+              "kind": "method",
+              "name": "#updateTokens",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "#tokenize",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "string[]"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "text",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#tokenizeWordPiece",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "string[]"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "text",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#tokenizeLLaMA",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "string[]"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "text",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#tokenizeCharacter",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "string[]"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "text",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#tokenizeWhitespace",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "string[]"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "text",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#tokenizeBPE",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "string[]"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "text",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#tokenizeSentencePiece",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "string[]"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "text",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#splitIntoSubwords",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "string[]"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "word",
+                  "type": {
+                    "text": "string"
+                  }
+                },
+                {
+                  "name": "format",
+                  "type": {
+                    "text": "'word-piece' | 'bpe' | 'sentence-piece' | 'llama' | 'character' | 'whitespace'"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#extractNextToken",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "string"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "text",
+                  "type": {
+                    "text": "string"
+                  }
+                },
+                {
+                  "name": "startIndex",
+                  "type": {
+                    "text": "number"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "#isAfterSpace",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "boolean"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "text",
+                  "type": {
+                    "text": "string"
+                  }
+                },
+                {
+                  "name": "index",
+                  "type": {
+                    "text": "number"
+                  }
+                }
+              ]
+            }
+          ],
+          "attributes": [
+            {
+              "name": "format",
+              "type": {
+                "text": "| 'bpe'\n    | 'word-piece'\n    | 'sentence-piece'\n    | 'llama'\n    | 'character'\n    | 'whitespace'"
+              },
+              "default": "'bpe'",
+              "description": "Tokenization format/strategy to use",
+              "fieldName": "format"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "bp-format-token",
+          "customElement": true,
+          "summary": "The format token component visualizes text tokenization for language models, displaying how text is split into tokens using various tokenization strategies like WordPiece, BPE, SentencePiece, and LLaMA.",
+          "metadata": {
+            "since": "2.8.0"
+          }
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "BpFormatToken",
+          "declaration": {
+            "name": "BpFormatToken",
+            "module": "/format-token/element.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "/format-token/element.visual.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "/format-token/index.js",
       "declarations": [],
       "exports": [
         {
@@ -11303,6 +12050,12 @@
     },
     {
       "kind": "javascript-module",
+      "path": "/include/format-bytes.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
       "path": "/include/format-datetime.js",
       "declarations": [],
       "exports": []
@@ -11310,6 +12063,18 @@
     {
       "kind": "javascript-module",
       "path": "/include/format-number.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "/include/format-relative-time.js",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "/include/format-token.js",
       "declarations": [],
       "exports": []
     },
@@ -19369,7 +20134,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "```typescript\nimport '@blueprintui/components/include/pagination.js';\n```\n\n```html\n<bp-pagination>\n  <bp-pagination-button action=\"first\" disabled></bp-pagination-button>\n  <bp-pagination-button action=\"prev\" disabled></bp-pagination-button>\n  <span aria-label=\"current page\">1 / 3</span>\n  <bp-pagination-button action=\"next\"></bp-pagination-button>\n  <bp-pagination-button action=\"last\"></bp-pagination-button>\n</bp-pagination>\n```",
+          "description": "```typescript\nimport '@blueprintui/components/include/pagination.js';\n```\n\n```html\n<bp-pagination aria-label=\"pagination\">\n  <bp-button-icon slot=\"first\"></bp-button-icon>\n  <bp-button-icon slot=\"prev\"></bp-button-icon>\n  <span aria-label=\"current page\">1 / 3</span>\n  <bp-button-icon slot=\"next\"></bp-button-icon>\n  <bp-button-icon slot=\"last\"></bp-button-icon>\n</bp-pagination>\n```",
           "name": "BpPagination",
           "cssProperties": [
             {
@@ -20748,6 +21513,14 @@
             {
               "description": "content",
               "name": ""
+            },
+            {
+              "description": "slot for popover header",
+              "name": "header"
+            },
+            {
+              "description": "slot for popover footer",
+              "name": "footer"
             }
           ],
           "members": [
@@ -22016,8 +22789,12 @@
               "name": "prefix"
             },
             {
-              "description": "slot for suffic text or icons",
+              "description": "slot for suffix text or icons",
               "name": "suffix"
+            },
+            {
+              "description": "slot for range input",
+              "name": ""
             }
           ],
           "members": [
@@ -27758,6 +28535,10 @@
                 "name": "BpInput",
                 "module": "/input/element.js"
               }
+            },
+            {
+              "description": "slot for time input",
+              "name": ""
             }
           ],
           "members": [

--- a/projects/components/src/format-relative-time/element.css
+++ b/projects/components/src/format-relative-time/element.css
@@ -1,0 +1,7 @@
+:host {
+  display: inline;
+}
+
+[part='internal'] {
+  display: contents;
+}

--- a/projects/components/src/format-relative-time/element.examples.js
+++ b/projects/components/src/format-relative-time/element.examples.js
@@ -1,0 +1,125 @@
+export const metadata = {
+  name: 'format-relative-time',
+  elements: ['bp-format-relative-time']
+};
+
+export function example() {
+  // Create dates for examples
+  const now = new Date();
+  const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000);
+  const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const threeDaysFromNow = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000);
+
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/format-relative-time.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <bp-format-relative-time>${twoHoursAgo.toISOString()}</bp-format-relative-time>
+
+      <bp-format-relative-time>${yesterday.toISOString()}</bp-format-relative-time>
+
+      <bp-format-relative-time>${threeDaysFromNow.toISOString()}</bp-format-relative-time>
+    </div>
+    `;
+}
+
+export function numericFormat() {
+  const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/format-relative-time.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <bp-format-relative-time numeric="auto">${yesterday.toISOString()}</bp-format-relative-time>
+
+      <bp-format-relative-time numeric="always">${yesterday.toISOString()}</bp-format-relative-time>
+    </div>
+    `;
+}
+
+export function styleVariations() {
+  const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/format-relative-time.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <bp-format-relative-time format-style="long">${twoHoursAgo.toISOString()}</bp-format-relative-time>
+
+      <bp-format-relative-time format-style="short">${twoHoursAgo.toISOString()}</bp-format-relative-time>
+
+      <bp-format-relative-time format-style="narrow">${twoHoursAgo.toISOString()}</bp-format-relative-time>
+    </div>
+    `;
+}
+
+export function specificUnit() {
+  const pastDate = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000); // 2 days ago
+
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/format-relative-time.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <bp-format-relative-time unit="auto">${pastDate.toISOString()}</bp-format-relative-time>
+
+      <bp-format-relative-time unit="hour">${pastDate.toISOString()}</bp-format-relative-time>
+
+      <bp-format-relative-time unit="day">${pastDate.toISOString()}</bp-format-relative-time>
+    </div>
+    `;
+}
+
+export function liveSync() {
+  const oneMinuteAgo = new Date(Date.now() - 60 * 1000);
+
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/format-relative-time.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <bp-format-relative-time>${oneMinuteAgo.toISOString()}</bp-format-relative-time>
+
+      <bp-format-relative-time sync>${oneMinuteAgo.toISOString()}</bp-format-relative-time>
+    </div>
+    `;
+}
+
+export function inlineText() {
+  const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/format-relative-time.js';
+    </script>
+
+    <p bp-text="content">
+      Last updated <bp-format-relative-time format-style="short">${oneHourAgo.toISOString()}</bp-format-relative-time>
+    </p>
+    `;
+}
+
+export function futureDate() {
+  const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000);
+  const nextWeek = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/format-relative-time.js';
+    </script>
+
+    <div bp-layout="block gap:md">
+      <bp-format-relative-time>${tomorrow.toISOString()}</bp-format-relative-time>
+
+      <bp-format-relative-time>${nextWeek.toISOString()}</bp-format-relative-time>
+    </div>
+    `;
+}

--- a/projects/components/src/format-relative-time/element.performance.ts
+++ b/projects/components/src/format-relative-time/element.performance.ts
@@ -1,0 +1,16 @@
+import { testBundleSize, testRenderTime, html } from 'web-test-runner-performance/browser.js';
+import '@blueprintui/components/include/format-relative-time.js';
+
+describe('bp-format-relative-time performance', () => {
+  const element = html`<bp-format-relative-time>2024-11-16T10:00:00Z</bp-format-relative-time>`;
+
+  it(`should bundle and treeshake under 8kb`, async () => {
+    expect(
+      (await testBundleSize('@blueprintui/components/include/format-relative-time.js', { optimize: true })).kb
+    ).toBeLessThan(8);
+  });
+
+  it(`should render under 20ms`, async () => {
+    expect((await testRenderTime(element)).duration).toBeLessThan(20);
+  });
+});

--- a/projects/components/src/format-relative-time/element.spec.ts
+++ b/projects/components/src/format-relative-time/element.spec.ts
@@ -1,0 +1,354 @@
+import { html } from 'lit';
+import '@blueprintui/components/include/format-relative-time.js';
+import { BpFormatRelativeTime } from '@blueprintui/components/format-relative-time';
+import { elementIsStable, createFixture, removeFixture } from '@blueprintui/test';
+
+describe('bp-format-relative-time', () => {
+  let fixture: HTMLElement;
+  let element: BpFormatRelativeTime;
+
+  beforeEach(async () => {
+    fixture = await createFixture(html`<bp-format-relative-time></bp-format-relative-time>`);
+    element = fixture.querySelector<BpFormatRelativeTime>('bp-format-relative-time');
+    await elementIsStable(element);
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('should register element', async () => {
+    await elementIsStable(element);
+    expect(customElements.get('bp-format-relative-time')).toBe(BpFormatRelativeTime);
+  });
+
+  it('should use a time tag format with a datetime attribute', async () => {
+    element.textContent = '2024-11-16T10:00:00Z';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const timeElement = element.shadowRoot.querySelector('time');
+    expect(timeElement).toBeTruthy();
+    expect(timeElement.getAttribute('datetime')).toBe('2024-11-16T10:00:00Z');
+  });
+
+  it('should format past time with "ago"', async () => {
+    const pastDate = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2 hours ago
+    element.textContent = pastDate.toISOString();
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('ago');
+  });
+
+  it('should format future time with "in"', async () => {
+    const futureDate = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000); // 3 days from now
+    element.textContent = futureDate.toISOString();
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('in');
+  });
+
+  it('should use numeric="always" format', async () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000); // 1 day ago
+    element.textContent = yesterday.toISOString();
+    element.numeric = 'always';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('1');
+  });
+
+  it('should use numeric="auto" format', async () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000); // 1 day ago
+    element.textContent = yesterday.toISOString();
+    element.numeric = 'auto';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text.toLowerCase()).toContain('yesterday');
+  });
+
+  it('should format with formatStyle="long"', async () => {
+    const pastDate = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2 hours ago
+    element.textContent = pastDate.toISOString();
+    element.formatStyle = 'long';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('hours');
+  });
+
+  it('should format with formatStyle="short"', async () => {
+    const pastDate = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2 hours ago
+    element.textContent = pastDate.toISOString();
+    element.formatStyle = 'short';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('hr');
+  });
+
+  it('should format with formatStyle="narrow"', async () => {
+    const pastDate = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2 hours ago
+    element.textContent = pastDate.toISOString();
+    element.formatStyle = 'narrow';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('h');
+  });
+
+  it('should auto-select unit for seconds', async () => {
+    const pastDate = new Date(Date.now() - 30 * 1000); // 30 seconds ago
+    element.textContent = pastDate.toISOString();
+    element.unit = 'auto';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('second');
+  });
+
+  it('should auto-select unit for minutes', async () => {
+    const pastDate = new Date(Date.now() - 5 * 60 * 1000); // 5 minutes ago
+    element.textContent = pastDate.toISOString();
+    element.unit = 'auto';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('minute');
+  });
+
+  it('should auto-select unit for hours', async () => {
+    const pastDate = new Date(Date.now() - 3 * 60 * 60 * 1000); // 3 hours ago
+    element.textContent = pastDate.toISOString();
+    element.unit = 'auto';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('hour');
+  });
+
+  it('should auto-select unit for days', async () => {
+    const pastDate = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000); // 2 days ago
+    element.textContent = pastDate.toISOString();
+    element.unit = 'auto';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('day');
+  });
+
+  it('should auto-select unit for weeks', async () => {
+    const pastDate = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000); // 10 days ago (about a week)
+    element.textContent = pastDate.toISOString();
+    element.unit = 'auto';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('week');
+  });
+
+  it('should auto-select unit for months', async () => {
+    const pastDate = new Date(Date.now() - 45 * 24 * 60 * 60 * 1000); // 45 days ago (about a month)
+    element.textContent = pastDate.toISOString();
+    element.unit = 'auto';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('month');
+  });
+
+  it('should auto-select unit for years', async () => {
+    const pastDate = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000); // 400 days ago (over a year)
+    element.textContent = pastDate.toISOString();
+    element.unit = 'auto';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('year');
+  });
+
+  it('should use specific unit="second"', async () => {
+    const pastDate = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2 hours ago
+    element.textContent = pastDate.toISOString();
+    element.unit = 'second';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('second');
+  });
+
+  it('should use specific unit="minute"', async () => {
+    const pastDate = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2 hours ago
+    element.textContent = pastDate.toISOString();
+    element.unit = 'minute';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('minute');
+  });
+
+  it('should use specific unit="hour"', async () => {
+    const pastDate = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000); // 2 days ago
+    element.textContent = pastDate.toISOString();
+    element.unit = 'hour';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('hour');
+  });
+
+  it('should use specific unit="day"', async () => {
+    const pastDate = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000); // 2 days ago
+    element.textContent = pastDate.toISOString();
+    element.unit = 'day';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('day');
+  });
+
+  it('should use specific unit="week"', async () => {
+    const pastDate = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000); // 14 days ago
+    element.textContent = pastDate.toISOString();
+    element.unit = 'week';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('week');
+  });
+
+  it('should use specific unit="month"', async () => {
+    const pastDate = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000); // 60 days ago
+    element.textContent = pastDate.toISOString();
+    element.unit = 'month';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('month');
+  });
+
+  it('should use specific unit="year"', async () => {
+    const pastDate = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000); // 400 days ago
+    element.textContent = pastDate.toISOString();
+    element.unit = 'year';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('year');
+  });
+
+  it('should handle text content parsing in connectedCallback', async () => {
+    const testDate = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    fixture = await createFixture(html`<bp-format-relative-time>${testDate.toISOString()}</bp-format-relative-time>`);
+    element = fixture.querySelector<BpFormatRelativeTime>('bp-format-relative-time');
+    await elementIsStable(element);
+
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toBeTruthy();
+    expect(text).toContain('ago');
+  });
+
+  it('should handle bp-textchange event', async () => {
+    const testDate = new Date(Date.now() - 3 * 60 * 60 * 1000);
+    element.textContent = testDate.toISOString();
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('ago');
+  });
+
+  it('should handle invalid date gracefully', async () => {
+    element.textContent = 'invalid-date';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toBe('');
+  });
+
+  it('should handle empty text content', async () => {
+    element.textContent = '';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toBe('');
+  });
+
+  it('should support locale formatting', async () => {
+    const pastDate = new Date(Date.now() - 2 * 60 * 60 * 1000); // 2 hours ago
+    element.textContent = pastDate.toISOString();
+    element.locale = 'en-US';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toBeTruthy();
+  });
+
+  it('should handle sync mode updates', async () => {
+    jasmine.clock().install();
+
+    const testDate = new Date(Date.now() - 30 * 1000); // 30 seconds ago
+    element.textContent = testDate.toISOString();
+    element.sync = true;
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+
+    const initialText = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(initialText).toBeTruthy();
+
+    // Fast forward 2 seconds
+    jasmine.clock().tick(2000);
+    await elementIsStable(element);
+
+    const updatedText = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(updatedText).toBeTruthy();
+
+    jasmine.clock().uninstall();
+  });
+
+  it('should clear sync interval when disconnected', async () => {
+    element.sync = true;
+    await elementIsStable(element);
+
+    const clearIntervalSpy = spyOn(window, 'clearInterval');
+    element.disconnectedCallback();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+  });
+
+  it('should update sync interval when sync property changes', async () => {
+    element.sync = false;
+    await elementIsStable(element);
+
+    element.sync = true;
+    await elementIsStable(element);
+
+    expect(element.sync).toBe(true);
+  });
+
+  it('should handle very recent time (< 1 second)', async () => {
+    const veryRecentDate = new Date(Date.now() - 500); // 500ms ago
+    element.textContent = veryRecentDate.toISOString();
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toBeTruthy();
+  });
+
+  it('should round to nearest second', async () => {
+    const pastDate = new Date(Date.now() - 45 * 1000); // 45 seconds ago
+    element.textContent = pastDate.toISOString();
+    element.unit = 'second';
+    element.dispatchEvent(new CustomEvent('bp-textchange'));
+    await elementIsStable(element);
+
+    const text = element.shadowRoot.querySelector('[part=internal]').textContent;
+    expect(text).toContain('45');
+  });
+});

--- a/projects/components/src/format-relative-time/element.ts
+++ b/projects/components/src/format-relative-time/element.ts
@@ -1,0 +1,218 @@
+import { html, LitElement } from 'lit';
+import { property } from 'lit/decorators/property.js';
+import { state } from 'lit/decorators/state.js';
+import { baseStyles, interactionTextChange } from '@blueprintui/components/internals';
+import styles from './element.css' with { type: 'css' };
+
+/**
+ * ```typescript
+ * import '@blueprintui/components/include/format-relative-time.js';
+ * ```
+ *
+ * ```html
+ * <bp-format-relative-time>2024-11-16T10:30:00Z</bp-format-relative-time>
+ * ```
+ *
+ * @summary The format-relative-time component displays relative time (e.g., "2 hours ago", "in 3 days") using the Intl.RelativeTimeFormat API.
+ * @element bp-format-relative-time
+ * @since 2.10.0
+ */
+@interactionTextChange()
+export class BpFormatRelativeTime extends LitElement {
+  /** determines how to format the time: 'auto' shows "yesterday" vs "1 day ago" */
+  @property({ type: String }) accessor numeric: 'always' | 'auto' = 'auto';
+
+  /** determines the formatting style: 'long', 'short', or 'narrow' */
+  @property({ type: String, attribute: 'format-style' }) accessor formatStyle: 'long' | 'short' | 'narrow' = 'long';
+
+  /** the time unit to use, or 'auto' to automatically select the best unit */
+  @property({ type: String }) accessor unit: 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year' | 'auto' =
+    'auto';
+
+  /** auto-update the displayed time at appropriate intervals */
+  @property({ type: Boolean }) accessor sync = false;
+
+  /** locale to use for formatting */
+  @property({ type: String }) accessor locale: string;
+
+  @state() private accessor _value: string = '';
+
+  @state() private accessor _now = Date.now();
+
+  #syncInterval: number | null = null;
+
+  static styles = [baseStyles, styles];
+
+  get #relativeTime() {
+    try {
+      const date = new Date(this._value);
+
+      if (isNaN(date.getTime())) {
+        console.warn('bp-format-relative-time: Invalid date value', this._value);
+        return '';
+      }
+
+      const diffMs = date.getTime() - this._now;
+      const diffSec = Math.round(diffMs / 1000);
+      const diffMin = Math.round(diffMs / 60000);
+      const diffHour = Math.round(diffMs / 3600000);
+      const diffDay = Math.round(diffMs / 86400000);
+      const diffWeek = Math.round(diffMs / 604800000);
+      const diffMonth = Math.round(diffMs / 2629800000); // average month
+      const diffYear = Math.round(diffMs / 31557600000); // average year
+
+      let value: number;
+      let selectedUnit: Intl.RelativeTimeFormatUnit;
+
+      if (this.unit !== 'auto') {
+        selectedUnit = this.unit;
+        switch (this.unit) {
+          case 'second':
+            value = diffSec;
+            break;
+          case 'minute':
+            value = diffMin;
+            break;
+          case 'hour':
+            value = diffHour;
+            break;
+          case 'day':
+            value = diffDay;
+            break;
+          case 'week':
+            value = diffWeek;
+            break;
+          case 'month':
+            value = diffMonth;
+            break;
+          case 'year':
+            value = diffYear;
+            break;
+          default:
+            value = diffSec;
+            selectedUnit = 'second';
+        }
+      } else {
+        // Auto-select the most appropriate unit
+        if (Math.abs(diffYear) >= 1) {
+          value = diffYear;
+          selectedUnit = 'year';
+        } else if (Math.abs(diffMonth) >= 1) {
+          value = diffMonth;
+          selectedUnit = 'month';
+        } else if (Math.abs(diffWeek) >= 1) {
+          value = diffWeek;
+          selectedUnit = 'week';
+        } else if (Math.abs(diffDay) >= 1) {
+          value = diffDay;
+          selectedUnit = 'day';
+        } else if (Math.abs(diffHour) >= 1) {
+          value = diffHour;
+          selectedUnit = 'hour';
+        } else if (Math.abs(diffMin) >= 1) {
+          value = diffMin;
+          selectedUnit = 'minute';
+        } else {
+          value = diffSec;
+          selectedUnit = 'second';
+        }
+      }
+
+      const formatter = new Intl.RelativeTimeFormat(this.locale, {
+        numeric: this.numeric,
+        style: this.formatStyle
+      });
+
+      return formatter.format(value, selectedUnit);
+    } catch (error) {
+      console.error('bp-format-relative-time: Error formatting relative time', error);
+      return '';
+    }
+  }
+
+  get #updateInterval() {
+    if (this.unit !== 'auto') {
+      switch (this.unit) {
+        case 'second':
+          return 1000; // 1 second
+        case 'minute':
+          return 60000; // 1 minute
+        case 'hour':
+          return 3600000; // 1 hour
+        case 'day':
+        case 'week':
+        case 'month':
+        case 'year':
+          return 86400000; // 1 day
+        default:
+          return 60000;
+      }
+    }
+
+    // Auto mode: determine interval based on time difference
+    try {
+      const date = new Date(this._value);
+      if (isNaN(date.getTime())) return 60000;
+
+      const diffMs = Math.abs(date.getTime() - this._now);
+      const diffMin = diffMs / 60000;
+      const diffHour = diffMs / 3600000;
+      const diffDay = diffMs / 86400000;
+
+      if (diffMin < 1) {
+        return 1000; // Update every second for recent times
+      } else if (diffHour < 1) {
+        return 60000; // Update every minute for times within an hour
+      } else if (diffDay < 1) {
+        return 3600000; // Update every hour for times within a day
+      } else {
+        return 86400000; // Update every day for older times
+      }
+    } catch {
+      return 60000; // Default to 1 minute
+    }
+  }
+
+  render() {
+    return html`<time part="internal" datetime=${this._value}>${this.#relativeTime}</time>`;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._value = this.textContent?.trim() || '';
+    this._now = Date.now();
+    this.addEventListener('bp-textchange', () => {
+      this._value = this.textContent?.trim() || '';
+      this._now = Date.now();
+    });
+    this.#setupSync();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.#clearSync();
+  }
+
+  updated(changedProperties: Map<string, any>) {
+    super.updated(changedProperties);
+    if (changedProperties.has('sync') || changedProperties.has('unit')) {
+      this.#setupSync();
+    }
+  }
+
+  #setupSync() {
+    this.#clearSync();
+    if (this.sync) {
+      this.#syncInterval = window.setInterval(() => {
+        this._now = Date.now();
+      }, this.#updateInterval);
+    }
+  }
+
+  #clearSync() {
+    if (this.#syncInterval !== null) {
+      clearInterval(this.#syncInterval);
+      this.#syncInterval = null;
+    }
+  }
+}

--- a/projects/components/src/format-relative-time/index.ts
+++ b/projects/components/src/format-relative-time/index.ts
@@ -1,0 +1,1 @@
+export * from './element.js';

--- a/projects/components/src/include/format-relative-time.ts
+++ b/projects/components/src/include/format-relative-time.ts
@@ -1,0 +1,10 @@
+import { BpFormatRelativeTime } from '@blueprintui/components/format-relative-time';
+import { defineElement } from '@blueprintui/components/internals';
+
+defineElement('bp-format-relative-time', BpFormatRelativeTime);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'bp-format-relative-time': BpFormatRelativeTime;
+  }
+}

--- a/projects/docs/src/_layouts/base.11ty.js
+++ b/projects/docs/src/_layouts/base.11ty.js
@@ -92,6 +92,7 @@ export function render(data) {
               <bp-tree-item ${data.page.url === '/docs/components/format-bytes.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/format-bytes.html">Format Bytes</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/format-datetime.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/format-datetime.html">Format Datetime</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/format-number.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/format-number.html">Format Number</a></bp-tree-item>
+              <bp-tree-item ${data.page.url === '/docs/components/format-relative-time.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/format-relative-time.html">Format Relative Time</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/format-token.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/format-token.html">Format Token</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/forms.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/forms.html">Forms</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/form-interactions.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/form-interactions.html">Form Interactions</a></bp-tree-item>

--- a/projects/docs/src/_pages/components/badge.11ty.js
+++ b/projects/docs/src/_pages/components/badge.11ty.js
@@ -1,4 +1,4 @@
-import schema from '../../../..//components/.drafter/schema.json' with { type: 'json' };
+import schema from '../../../../components/.drafter/schema.json' with { type: 'json' };
 import { getImport, getExample, getAPI, getElementSummary } from '../../_includes/utils/index.js';
 
 export const data = {

--- a/projects/docs/src/_pages/components/format-relative-time.11ty.js
+++ b/projects/docs/src/_pages/components/format-relative-time.11ty.js
@@ -1,0 +1,31 @@
+import schema from '../../../..//components/.drafter/schema.json' with { type: 'json' };
+import { getImport, getExample, getAPI, getElementSummary } from '../../_includes/utils/index.js';
+
+export const data = {
+  title: 'Format Relative Time',
+  schema: schema.find(c => c.name === 'format-relative-time')
+};
+
+export function render() {
+  return /* markdown */`
+${getElementSummary(data.schema, 'bp-format-relative-time')}
+
+${getExample(data.schema, 'example')}
+
+${getExample(data.schema, 'numeric-format')}
+
+${getExample(data.schema, 'style-variations')}
+
+${getExample(data.schema, 'specific-unit')}
+
+${getExample(data.schema, 'live-sync')}
+
+${getExample(data.schema, 'future-date')}
+
+${getExample(data.schema, 'inline-text')}
+
+${getImport(data.schema)}
+
+${getAPI(data.schema)}
+`;
+}

--- a/projects/docs/src/index.css
+++ b/projects/docs/src/index.css
@@ -109,6 +109,10 @@ bp-panel#nav-panel {
   }
 }
 
+#article-content > [bp-text='subsection'] {
+  text-wrap: initial;
+}
+
 article aside {
   padding-left: 12px;
   position: sticky;

--- a/projects/grid/custom-elements.lock.json
+++ b/projects/grid/custom-elements.lock.json
@@ -1239,12 +1239,6 @@
               "name": "--body-height"
             },
             {
-              "name": "--scrollbar-background"
-            },
-            {
-              "name": "--scrollbar-thumb-background"
-            },
-            {
               "name": "--column-height"
             },
             {


### PR DESCRIPTION
Add new format-relative-time component for displaying relative time (e.g., "2 hours ago", "in 3 days") using the Intl.RelativeTimeFormat API.

Features:
- Auto-select or manually specify time units (second to year)
- Multiple formatting styles (long, short, narrow)
- Support for both numeric formats (auto/always)
- Optional live sync mode with smart interval updates
- Locale support via Intl API
- Future and past date handling

Includes:
- Core component implementation
- Unit tests with comprehensive coverage
- Performance tests
- Visual regression tests
- Component examples
- Documentation page