### PR TITLE
Add bp-split-view

### DIFF
--- a/projects/components/src/include/all.ts
+++ b/projects/components/src/include/all.ts
@@ -43,6 +43,7 @@ import '@blueprintui/components/include/rating.js';
 import '@blueprintui/components/include/search.js';
 import '@blueprintui/components/include/select.js';
 import '@blueprintui/components/include/skeleton.js';
+import '@blueprintui/components/include/split-view.js';
 import '@blueprintui/components/include/switch.js';
 import '@blueprintui/components/include/tabs.js';
 import '@blueprintui/components/include/tag.js';

--- a/projects/components/src/include/lazy.ts
+++ b/projects/components/src/include/lazy.ts
@@ -42,6 +42,7 @@ export const loader = {
   search: () => import('@blueprintui/components/include/search.js'),
   select: () => import('@blueprintui/components/include/select.js'),
   skeleton: () => import('@blueprintui/components/include/skeleton.js'),
+  'split-view': () => import('@blueprintui/components/include/split-view.js'),
   stepper: () => import('@blueprintui/components/include/stepper.js'),
   switch: () => import('@blueprintui/components/include/switch.js'),
   tabs: () => import('@blueprintui/components/include/tabs.js'),

--- a/projects/components/src/include/split-view.ts
+++ b/projects/components/src/include/split-view.ts
@@ -1,0 +1,11 @@
+import { defineElement } from '@blueprintui/components/internals';
+import { BpSplitView } from '@blueprintui/components/split-view';
+import './button-resize.js';
+
+defineElement('bp-split-view', BpSplitView);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'bp-split-view': BpSplitView;
+  }
+}

--- a/projects/components/src/split-view/element.css
+++ b/projects/components/src/split-view/element.css
@@ -1,0 +1,59 @@
+:host {
+  --divider-width: var(--bp-size-100);
+  --divider-color: var(--bp-layer-border-100);
+  --divider-color-hover: var(--bp-layer-border-200);
+  --divider-color-active: var(--bp-object-border-accent-100);
+  --divider-color-focus: var(--bp-object-border-accent-200);
+  --divider-hit-area: 11px;
+
+  display: grid;
+  grid-template-columns: auto var(--divider-width) auto;
+  grid-template-rows: 100%;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+:host([vertical]) {
+  grid-template-columns: 100%;
+  grid-template-rows: auto var(--divider-width) auto;
+}
+
+.pane {
+  overflow: auto;
+  min-width: 0;
+  min-height: 0;
+}
+
+bp-button-resize {
+  --background: var(--divider-color);
+  --width: var(--divider-width);
+  --height: 100%;
+  cursor: col-resize;
+  z-index: 1;
+}
+
+:host([vertical]) bp-button-resize {
+  --width: 100%;
+  --height: var(--divider-width);
+  cursor: row-resize;
+}
+
+bp-button-resize:hover {
+  --background: var(--divider-color-hover);
+}
+
+bp-button-resize:active {
+  --background: var(--divider-color-active);
+}
+
+bp-button-resize:focus-visible {
+  --background: var(--divider-color-focus);
+  outline: var(--bp-object-border-accent-200) solid var(--bp-border-width-100);
+  outline-offset: calc(-1 * var(--bp-border-width-100));
+}
+
+:host([disabled]) bp-button-resize {
+  cursor: default;
+  opacity: 0.6;
+}

--- a/projects/components/src/split-view/element.examples.js
+++ b/projects/components/src/split-view/element.examples.js
@@ -1,0 +1,163 @@
+export const metadata = {
+  name: 'split-view',
+  elements: ['bp-split-view']
+};
+
+export function example() {
+  return /* html */ `
+    <script type="module">
+      import '@blueprintui/components/include/split-view.js';
+    </script>
+    <bp-split-view style="height: 300px;">
+      <div slot="prefix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-100);">
+        <p>Left Panel</p>
+        <p>This is the prefix panel. You can resize by dragging the divider.</p>
+      </div>
+      <div slot="suffix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-200);">
+        <p>Right Panel</p>
+        <p>This is the suffix panel.</p>
+      </div>
+    </bp-split-view>
+  `;
+}
+
+export function vertical() {
+  return /* html */ `
+    <bp-split-view vertical style="height: 400px;">
+      <div slot="prefix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-100);">
+        <p>Top Panel</p>
+        <p>Vertical split view with top and bottom panels.</p>
+      </div>
+      <div slot="suffix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-200);">
+        <p>Bottom Panel</p>
+        <p>Drag the horizontal divider to resize.</p>
+      </div>
+    </bp-split-view>
+  `;
+}
+
+export function customPosition() {
+  return /* html */ `
+    <bp-split-view position="25" style="height: 300px;">
+      <div slot="prefix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-100);">
+        <p>25% Width</p>
+      </div>
+      <div slot="suffix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-200);">
+        <p>75% Width</p>
+      </div>
+    </bp-split-view>
+  `;
+}
+
+export function pixelPosition() {
+  return /* html */ `
+    <bp-split-view position="200" position-in-pixels style="height: 300px; width: 600px;">
+      <div slot="prefix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-100);">
+        <p>200px Width</p>
+      </div>
+      <div slot="suffix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-200);">
+        <p>Remaining Width</p>
+      </div>
+    </bp-split-view>
+  `;
+}
+
+export function withConstraints() {
+  return /* html */ `
+    <bp-split-view prefix-min="100" prefix-max="400" suffix-min="150" style="height: 300px;">
+      <div slot="prefix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-100);">
+        <p>Constrained Panel</p>
+        <p>Min: 100px, Max: 400px</p>
+      </div>
+      <div slot="suffix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-200);">
+        <p>Constrained Panel</p>
+        <p>Min: 150px</p>
+      </div>
+    </bp-split-view>
+  `;
+}
+
+export function snapPoints() {
+  return /* html */ `
+    <bp-split-view snap="25 50 75" snap-threshold="15" style="height: 300px;">
+      <div slot="prefix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-100);">
+        <p>Snap to 25%, 50%, or 75%</p>
+      </div>
+      <div slot="suffix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-200);">
+        <p>Try dragging the divider near these positions</p>
+      </div>
+    </bp-split-view>
+  `;
+}
+
+export function disabled() {
+  return /* html */ `
+    <bp-split-view disabled position="40" style="height: 300px;">
+      <div slot="prefix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-100);">
+        <p>Fixed Panel</p>
+      </div>
+      <div slot="suffix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-200);">
+        <p>Cannot Resize (Disabled)</p>
+      </div>
+    </bp-split-view>
+  `;
+}
+
+export function customDivider() {
+  return /* html */ `
+    <bp-split-view
+      style="height: 300px; --divider-width: 2px; --divider-color: var(--bp-object-border-accent-100);">
+      <div slot="prefix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-100);">
+        <p>Custom Divider Style</p>
+      </div>
+      <div slot="suffix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-200);">
+        <p>Thin accent-colored divider</p>
+      </div>
+    </bp-split-view>
+  `;
+}
+
+export function nested() {
+  return /* html */ `
+    <bp-split-view position="25" style="height: 400px;">
+      <aside slot="prefix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-100);">
+        <h3 style="margin: 0 0 var(--bp-size-400);">Sidebar</h3>
+        <p>Navigation items</p>
+      </aside>
+      <bp-split-view slot="suffix" vertical position="30">
+        <header slot="prefix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-200);">
+          <h3 style="margin: 0;">Header</h3>
+        </header>
+        <main slot="suffix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-100);">
+          <h3 style="margin: 0 0 var(--bp-size-400);">Content Area</h3>
+          <p>Nested split view example with sidebar and header.</p>
+        </main>
+      </bp-split-view>
+    </bp-split-view>
+  `;
+}
+
+export function events() {
+  return /* html */ `
+    <script type="module">
+      const splitView = document.querySelector('#event-demo');
+      const output = document.querySelector('#event-output');
+
+      splitView.addEventListener('input', (e) => {
+        output.textContent = \`Position during drag: \${e.target.position.toFixed(1)}%\`;
+      });
+
+      splitView.addEventListener('change', (e) => {
+        output.textContent = \`Final position: \${e.target.position.toFixed(1)}%\`;
+      });
+    </script>
+    <bp-split-view id="event-demo" style="height: 300px;">
+      <div slot="prefix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-100);">
+        <p>Drag to see events</p>
+      </div>
+      <div slot="suffix" style="padding: var(--bp-size-600); background: var(--bp-layer-background-200);">
+        <p id="event-output">Position: 50.0%</p>
+      </div>
+    </bp-split-view>
+  `;
+}

--- a/projects/components/src/split-view/element.performance.ts
+++ b/projects/components/src/split-view/element.performance.ts
@@ -1,0 +1,10 @@
+import { testBundleSize } from 'web-test-runner-performance/browser.js';
+import '@blueprintui/components/include/split-view.js';
+
+describe('bp-split-view performance', () => {
+  it(`should bundle and treeshake under 12kb`, async () => {
+    expect((await testBundleSize('@blueprintui/components/include/split-view.js', { optimize: true })).kb).toBeLessThan(
+      12
+    );
+  });
+});

--- a/projects/components/src/split-view/element.spec.ts
+++ b/projects/components/src/split-view/element.spec.ts
@@ -1,0 +1,243 @@
+import { html } from 'lit';
+import { BpSplitView } from '@blueprintui/components/split-view';
+import { elementIsStable, createFixture, removeFixture, onceEvent } from '@blueprintui/test';
+import '@blueprintui/components/include/split-view.js';
+
+describe('split-view element', () => {
+  let fixture: HTMLElement;
+  let element: BpSplitView;
+
+  beforeEach(async () => {
+    fixture = await createFixture(html`
+      <bp-split-view>
+        <div slot="prefix">Left Panel</div>
+        <div slot="suffix">Right Panel</div>
+      </bp-split-view>
+    `);
+    element = fixture.querySelector<BpSplitView>('bp-split-view');
+    await elementIsStable(element);
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('should register element', async () => {
+    await elementIsStable(element);
+    expect(customElements.get('bp-split-view')).toBe(BpSplitView);
+  });
+
+  it('should have default property values', async () => {
+    await elementIsStable(element);
+    expect(element.vertical).toBe(false);
+    expect(element.position).toBe(50);
+    expect(element.positionInPixels).toBe(false);
+    expect(element.prefixMin).toBe(0);
+    expect(element.prefixMax).toBe(undefined);
+    expect(element.suffixMin).toBe(0);
+    expect(element.suffixMax).toBe(undefined);
+    expect(element.disabled).toBe(false);
+    expect(element.snap).toBe(undefined);
+    expect(element.snapThreshold).toBe(12);
+    expect(element.label).toBe('Resize panels');
+  });
+
+  it('should render prefix and suffix slots', async () => {
+    await elementIsStable(element);
+    const prefixSlot = element.shadowRoot?.querySelector('slot[name="prefix"]');
+    const suffixSlot = element.shadowRoot?.querySelector('slot[name="suffix"]');
+    expect(prefixSlot).toBeTruthy();
+    expect(suffixSlot).toBeTruthy();
+  });
+
+  it('should render bp-button-resize divider', async () => {
+    await elementIsStable(element);
+    const divider = element.shadowRoot?.querySelector('bp-button-resize');
+    expect(divider).toBeTruthy();
+    expect(divider?.orientation).toBe('horizontal');
+  });
+
+  it('should support vertical orientation', async () => {
+    element.vertical = true;
+    await elementIsStable(element);
+    const divider = element.shadowRoot?.querySelector('bp-button-resize');
+    expect(divider?.orientation).toBe('vertical');
+    expect(element.hasAttribute('vertical')).toBe(true);
+  });
+
+  it('should support horizontal orientation (default)', async () => {
+    await elementIsStable(element);
+    const divider = element.shadowRoot?.querySelector('bp-button-resize');
+    expect(divider?.orientation).toBe('horizontal');
+    expect(element.hasAttribute('vertical')).toBe(false);
+  });
+
+  it('should set position as percentage by default', async () => {
+    element.position = 30;
+    await elementIsStable(element);
+    expect(element.position).toBe(30);
+    expect(element.positionInPixels).toBe(false);
+  });
+
+  it('should support position in pixels', async () => {
+    element.positionInPixels = true;
+    element.position = 200;
+    await elementIsStable(element);
+    expect(element.position).toBe(200);
+    expect(element.positionInPixels).toBe(true);
+  });
+
+  it('should update position via setPosition method', async () => {
+    element.setPosition(75);
+    await elementIsStable(element);
+    expect(element.position).toBe(75);
+    expect(element.positionInPixels).toBe(false);
+  });
+
+  it('should update position in pixels via setPosition method', async () => {
+    element.setPosition(300, true);
+    await elementIsStable(element);
+    expect(element.position).toBe(300);
+    expect(element.positionInPixels).toBe(true);
+  });
+
+  it('should get position via getPosition method', async () => {
+    element.position = 60;
+    await elementIsStable(element);
+    expect(element.getPosition()).toBe(60);
+  });
+
+  it('should emit input event during resize', async () => {
+    const inputEvent = onceEvent(element, 'input');
+    const divider = element.shadowRoot?.querySelector('bp-button-resize');
+    divider?.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    await elementIsStable(element);
+    const event = await inputEvent;
+    expect(event).toBeTruthy();
+  });
+
+  it('should emit change event on resize end', async () => {
+    const changeEvent = onceEvent(element, 'change');
+    const divider = element.shadowRoot?.querySelector('bp-button-resize');
+    divider?.dispatchEvent(new InputEvent('change', { bubbles: true }));
+    await elementIsStable(element);
+    const event = await changeEvent;
+    expect(event).toBeTruthy();
+  });
+
+  it('should support disabled state', async () => {
+    element.disabled = true;
+    await elementIsStable(element);
+    const divider = element.shadowRoot?.querySelector('bp-button-resize');
+    expect(element.disabled).toBe(true);
+    expect(divider?.disabled).toBe(true);
+    expect(element.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('should support prefix-min constraint', async () => {
+    element.prefixMin = 100;
+    await elementIsStable(element);
+    expect(element.prefixMin).toBe(100);
+    expect(element.hasAttribute('prefix-min')).toBe(true);
+  });
+
+  it('should support prefix-max constraint', async () => {
+    element.prefixMax = 500;
+    await elementIsStable(element);
+    expect(element.prefixMax).toBe(500);
+    expect(element.hasAttribute('prefix-max')).toBe(true);
+  });
+
+  it('should support suffix-min constraint', async () => {
+    element.suffixMin = 150;
+    await elementIsStable(element);
+    expect(element.suffixMin).toBe(150);
+    expect(element.hasAttribute('suffix-min')).toBe(true);
+  });
+
+  it('should support suffix-max constraint', async () => {
+    element.suffixMax = 600;
+    await elementIsStable(element);
+    expect(element.suffixMax).toBe(600);
+    expect(element.hasAttribute('suffix-max')).toBe(true);
+  });
+
+  it('should support snap points', async () => {
+    element.snap = '25 50 75';
+    await elementIsStable(element);
+    expect(element.snap).toBe('25 50 75');
+  });
+
+  it('should support snap threshold', async () => {
+    element.snapThreshold = 20;
+    await elementIsStable(element);
+    expect(element.snapThreshold).toBe(20);
+  });
+
+  it('should support custom aria-label', async () => {
+    element.label = 'Resize code editor';
+    await elementIsStable(element);
+    const divider = element.shadowRoot?.querySelector('bp-button-resize');
+    expect(divider?.getAttribute('aria-label')).toBe('Resize code editor');
+  });
+
+  it('should expose CSS parts', async () => {
+    await elementIsStable(element);
+    const divider = element.shadowRoot?.querySelector('[part="divider"]');
+    const prefixPane = element.shadowRoot?.querySelector('[part="prefix-pane"]');
+    const suffixPane = element.shadowRoot?.querySelector('[part="suffix-pane"]');
+    expect(divider).toBeTruthy();
+    expect(prefixPane).toBeTruthy();
+    expect(suffixPane).toBeTruthy();
+  });
+
+  it('should apply correct CSS classes to panes', async () => {
+    await elementIsStable(element);
+    const prefixPane = element.shadowRoot?.querySelector('.pane.prefix');
+    const suffixPane = element.shadowRoot?.querySelector('.pane.suffix');
+    expect(prefixPane).toBeTruthy();
+    expect(suffixPane).toBeTruthy();
+  });
+
+  it('should update divider value when position changes', async () => {
+    element.position = 70;
+    await elementIsStable(element);
+    const divider = element.shadowRoot?.querySelector('bp-button-resize');
+    expect(divider?.value).toBe(70);
+  });
+
+  it('should handle position changes reactively', async () => {
+    element.position = 25;
+    await elementIsStable(element);
+    expect(element.position).toBe(25);
+
+    element.position = 75;
+    await elementIsStable(element);
+    expect(element.position).toBe(75);
+  });
+
+  it('should handle vertical orientation attribute', async () => {
+    element.setAttribute('vertical', '');
+    await elementIsStable(element);
+    expect(element.vertical).toBe(true);
+  });
+
+  it('should handle position-in-pixels attribute', async () => {
+    element.setAttribute('position-in-pixels', '');
+    await elementIsStable(element);
+    expect(element.positionInPixels).toBe(true);
+  });
+
+  it('should render with correct grid layout for horizontal', async () => {
+    await elementIsStable(element);
+    const style = getComputedStyle(element);
+    expect(style.display).toBe('grid');
+  });
+
+  it('should render with correct grid layout for vertical', async () => {
+    element.vertical = true;
+    await elementIsStable(element);
+    const style = getComputedStyle(element);
+    expect(style.display).toBe('grid');
+  });
+});

--- a/projects/components/src/split-view/element.ts
+++ b/projects/components/src/split-view/element.ts
@@ -1,0 +1,255 @@
+import { LitElement, html } from 'lit';
+import { property } from 'lit/decorators/property.js';
+import { state } from 'lit/decorators/state.js';
+import { baseStyles } from '@blueprintui/components/internals';
+import type { BpButtonResize } from '../button-resize/element.js';
+import styles from './element.css' with { type: 'css' };
+
+/**
+ * ```typescript
+ * import '@blueprintui/components/include/split-view.js';
+ * ```
+ *
+ * ```html
+ * <bp-split-view>
+ *   <div slot="prefix">Left/Top Panel</div>
+ *   <div slot="suffix">Right/Bottom Panel</div>
+ * </bp-split-view>
+ * ```
+ *
+ * @summary A split view component that allows resizing of two panels with a draggable divider
+ * @element bp-split-view
+ * @since 2.11.0
+ * @slot prefix - Content for the left/top panel
+ * @slot suffix - Content for the right/bottom panel
+ * @event {InputEvent} input - Fires during drag
+ * @event {InputEvent} change - Fires on drag end
+ * @cssprop --divider-width - Width of the divider
+ * @cssprop --divider-color - Color of the divider
+ * @cssprop --divider-color-hover - Color of the divider on hover
+ * @cssprop --divider-color-active - Color of the divider when active
+ * @cssprop --divider-color-focus - Color of the divider when focused
+ * @cssprop --divider-hit-area - Size of the grabbable area
+ */
+export class BpSplitView extends LitElement {
+  /** vertical orientation (horizontal by default) */
+  @property({ type: Boolean }) accessor vertical = false;
+
+  /** position in percentage (0-100) or pixels */
+  @property({ type: Number }) accessor position = 50;
+
+  /** whether position is in pixels */
+  @property({ type: Boolean, attribute: 'position-in-pixels' }) accessor positionInPixels = false;
+
+  /** minimum size for prefix panel in pixels */
+  @property({ type: Number, attribute: 'prefix-min' }) accessor prefixMin = 0;
+
+  /** maximum size for prefix panel in pixels */
+  @property({ type: Number, attribute: 'prefix-max' }) accessor prefixMax: number | undefined = undefined;
+
+  /** minimum size for suffix panel in pixels */
+  @property({ type: Number, attribute: 'suffix-min' }) accessor suffixMin = 0;
+
+  /** maximum size for suffix panel in pixels */
+  @property({ type: Number, attribute: 'suffix-max' }) accessor suffixMax: number | undefined = undefined;
+
+  /** prevents resizing */
+  @property({ type: Boolean }) accessor disabled = false;
+
+  /** snap positions (e.g., "25 50 75" or "repeat(100px)") */
+  @property({ type: String }) accessor snap: string | undefined = undefined;
+
+  /** pixel distance to trigger snap */
+  @property({ type: Number, attribute: 'snap-threshold' }) accessor snapThreshold = 12;
+
+  /** aria-label for the splitter */
+  @property({ type: String }) accessor label = 'Resize panels';
+
+  @state() private containerSize = 0;
+
+  @state() private actualPosition = 50;
+
+  static styles = [baseStyles, styles];
+
+  render() {
+    return html`
+      <div part="prefix-pane" class="pane prefix" style=${this.#prefixStyle}>
+        <slot name="prefix"></slot>
+      </div>
+      <bp-button-resize
+        part="divider"
+        .orientation=${this.vertical ? 'vertical' : 'horizontal'}
+        .value=${this.actualPosition}
+        .min=${0}
+        .max=${100}
+        .step=${1}
+        .disabled=${this.disabled}
+        aria-label=${this.label}
+        @input=${this.#handleInput}
+        @change=${this.#handleChange}></bp-button-resize>
+      <div part="suffix-pane" class="pane suffix" style=${this.#suffixStyle}>
+        <slot name="suffix"></slot>
+      </div>
+    `;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.#updateContainerSize();
+    window.addEventListener('resize', this.#handleResize);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('resize', this.#handleResize);
+  }
+
+  firstUpdated() {
+    this.#updateContainerSize();
+    this.#updatePosition(this.position);
+  }
+
+  updated(changedProperties: Map<string, any>) {
+    if (changedProperties.has('position') || changedProperties.has('positionInPixels')) {
+      this.#updatePosition(this.position);
+    }
+    if (changedProperties.has('vertical')) {
+      this.#updateContainerSize();
+    }
+  }
+
+  /** Get current position */
+  getPosition(): number {
+    return this.position;
+  }
+
+  /** Set position programmatically */
+  setPosition(value: number, inPixels = false): void {
+    this.positionInPixels = inPixels;
+    this.position = value;
+  }
+
+  get #prefixStyle() {
+    const size = this.vertical ? 'height' : 'width';
+    return `${size}: ${this.actualPosition}%`;
+  }
+
+  get #suffixStyle() {
+    const size = this.vertical ? 'height' : 'width';
+    return `${size}: ${100 - this.actualPosition}%`;
+  }
+
+  #handleResize = () => {
+    this.#updateContainerSize();
+    this.#updatePosition(this.position);
+  };
+
+  #updateContainerSize() {
+    const rect = this.getBoundingClientRect();
+    this.containerSize = this.vertical ? rect.height : rect.width;
+  }
+
+  #handleInput = (e: InputEvent) => {
+    const target = e.target as BpButtonResize;
+    let newPosition = target.valueAsNumber;
+
+    // Apply constraints
+    newPosition = this.#applyConstraints(newPosition);
+
+    // Apply snap
+    if (this.snap) {
+      newPosition = this.#applySnap(newPosition);
+    }
+
+    this.actualPosition = newPosition;
+    this.position = this.positionInPixels ? this.#percentToPixels(newPosition) : newPosition;
+
+    this.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
+  };
+
+  #handleChange = () => {
+    this.dispatchEvent(new InputEvent('change', { bubbles: true, composed: true }));
+  };
+
+  #updatePosition(value: number) {
+    let percentValue = this.positionInPixels ? this.#pixelsToPercent(value) : value;
+    percentValue = this.#applyConstraints(percentValue);
+    this.actualPosition = percentValue;
+  }
+
+  #pixelsToPercent(pixels: number): number {
+    if (this.containerSize === 0) return 50;
+    return (pixels / this.containerSize) * 100;
+  }
+
+  #percentToPixels(percent: number): number {
+    return (percent / 100) * this.containerSize;
+  }
+
+  #applyConstraints(percent: number): number {
+    const pixels = this.#percentToPixels(percent);
+    const suffixPixels = this.containerSize - pixels;
+
+    let constrainedPixels = pixels;
+
+    // Apply prefix constraints
+    if (this.prefixMin > 0 && pixels < this.prefixMin) {
+      constrainedPixels = this.prefixMin;
+    }
+    if (this.prefixMax !== undefined && pixels > this.prefixMax) {
+      constrainedPixels = this.prefixMax;
+    }
+
+    // Apply suffix constraints
+    if (this.suffixMin > 0 && suffixPixels < this.suffixMin) {
+      constrainedPixels = this.containerSize - this.suffixMin;
+    }
+    if (this.suffixMax !== undefined && suffixPixels > this.suffixMax) {
+      constrainedPixels = this.containerSize - this.suffixMax;
+    }
+
+    return this.#pixelsToPercent(constrainedPixels);
+  }
+
+  #applySnap(percent: number): number {
+    if (!this.snap) return percent;
+
+    const snapPoints = this.#parseSnapPoints();
+    if (snapPoints.length === 0) return percent;
+
+    // Find closest snap point
+    let closestPoint = percent;
+    let closestDistance = Infinity;
+
+    for (const point of snapPoints) {
+      const distance = Math.abs(percent - point);
+      if (distance < closestDistance && distance <= this.#pixelsToPercent(this.snapThreshold)) {
+        closestDistance = distance;
+        closestPoint = point;
+      }
+    }
+
+    return closestPoint;
+  }
+
+  #parseSnapPoints(): number[] {
+    if (!this.snap) return [];
+
+    // Handle "repeat(100px)" format
+    const repeatMatch = this.snap.match(/repeat\((\d+)px\)/);
+    if (repeatMatch) {
+      const interval = parseInt(repeatMatch[1]);
+      const points: number[] = [];
+      for (let i = 0; i <= this.containerSize; i += interval) {
+        points.push(this.#pixelsToPercent(i));
+      }
+      return points;
+    }
+
+    // Handle space-separated percentage values
+    return this.snap
+      .split(/\s+/)
+      .map(s => parseFloat(s))
+      .filter(n => !isNaN(n));
+  }
+}

--- a/projects/components/src/split-view/element.visual.ts
+++ b/projects/components/src/split-view/element.visual.ts
@@ -1,0 +1,33 @@
+import { html } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { visualDiff } from '@web/test-runner-visual-regression';
+import { createVisualFixture, removeFixture } from '@blueprintui/test';
+import * as splitView from './element.examples.js';
+import '@blueprintui/components/include/split-view.js';
+
+describe('bp-split-view', () => {
+  let fixture: HTMLElement;
+
+  beforeEach(async () => {
+    fixture = await createVisualFixture(html`
+      <div bp-layout="block gap:md">
+        ${unsafeHTML(splitView.example())} ${unsafeHTML(splitView.vertical())} ${unsafeHTML(splitView.customPosition())}
+        ${unsafeHTML(splitView.withConstraints())} ${unsafeHTML(splitView.disabled())}
+        ${unsafeHTML(splitView.customDivider())}
+      </div>
+    `);
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('light theme', async () => {
+    await visualDiff(fixture, 'split-view/light.png');
+  });
+
+  it('dark theme', async () => {
+    document.documentElement.setAttribute('bp-theme', 'dark');
+    await visualDiff(fixture, 'split-view/dark.png');
+  });
+});

--- a/projects/components/src/split-view/index.ts
+++ b/projects/components/src/split-view/index.ts
@@ -1,0 +1,1 @@
+export * from './element.js';


### PR DESCRIPTION
Add a new split-view component that allows resizing of two panels with a draggable divider.

Features:
- Horizontal and vertical orientation support
- Position control in percentage or pixels
- Min/max constraints for both panels
- Snap points with configurable threshold
- Disabled state support
- Keyboard navigation via internal bp-button-resize
- Input and change events following Blueprint patterns
- Full accessibility with aria-label support
- CSS custom properties for divider styling
- CSS shadow parts for customization

Files added:
- element.ts: Main component implementation
- element.css: Styles with design tokens
- element.spec.ts: Comprehensive unit tests
- element.visual.ts: Visual regression tests
- element.performance.ts: Bundle size tests
- element.examples.js: Documentation examples
- index.ts: Public exports
- include/split-view.ts: Component registration

Updated files:
- include/all.ts: Added split-view import
- include/lazy.ts: Added split-view loader