### PR TITLE
bp-button-captions

### DIFF
--- a/projects/components/src/button-captions/element.css
+++ b/projects/components/src/button-captions/element.css
@@ -1,0 +1,68 @@
+:host {
+  --width: var(--bp-interaction-touch-target);
+  --height: var(--bp-interaction-touch-target);
+  --background: var(--bp-layer-background-100);
+  --color: var(--bp-text-200);
+  --border-color: var(--bp-border-200);
+  --border-radius: var(--bp-border-radius-100);
+  --padding: var(--bp-spacing-100);
+  --background-hover: var(--bp-layer-background-200);
+  --background-pressed: var(--bp-layer-background-200);
+  --color-pressed: var(--bp-accent-700);
+  --border-color-pressed: var(--bp-accent-700);
+  --cursor: pointer;
+  width: var(--width);
+  height: var(--height);
+  display: inline-flex;
+}
+
+:host(:state(disabled)) {
+  --cursor: default;
+  opacity: 0.4;
+}
+
+:host(:state(readonly)) {
+  --cursor: default;
+  --pointer-events: none;
+}
+
+:host(:hover:not(:state(disabled)):not(:state(readonly))) {
+  --background: var(--background-hover);
+}
+
+:host([checked]) {
+  --background: var(--background-pressed);
+  --color: var(--color-pressed);
+  --border-color: var(--border-color-pressed);
+}
+
+:host(:active:not(:state(disabled)):not(:state(readonly))) [part='button'] {
+  transform: translateY(calc(var(--bp-size-100) / 2));
+}
+
+[part='button'] {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--background);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  padding: var(--padding);
+  cursor: var(--cursor);
+  pointer-events: var(--pointer-events, auto);
+}
+
+[part='icon'] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color);
+}
+
+bp-icon,
+::slotted(bp-icon) {
+  --color: inherit;
+  cursor: var(--cursor) !important;
+}

--- a/projects/components/src/button-captions/element.examples.js
+++ b/projects/components/src/button-captions/element.examples.js
@@ -1,0 +1,131 @@
+export const metadata = {
+  name: 'button-captions',
+  elements: ['bp-button-captions']
+};
+
+export function example() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/button-captions.js';
+    </script>
+
+    <div bp-layout="inline gap:lg">
+      <bp-button-captions aria-label="enable captions"></bp-button-captions>
+      <bp-button-captions checked aria-label="disable captions"></bp-button-captions>
+    </div>
+  `;
+}
+
+export function checked() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/button-captions.js';
+    </script>
+
+    <div bp-layout="inline gap:lg">
+      <bp-button-captions aria-label="enable captions"></bp-button-captions>
+      <bp-button-captions checked aria-label="disable captions"></bp-button-captions>
+    </div>
+  `;
+}
+
+export function disabled() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/button-captions.js';
+    </script>
+
+    <div bp-layout="inline gap:lg">
+      <bp-button-captions disabled aria-label="captions unavailable"></bp-button-captions>
+      <bp-button-captions checked disabled aria-label="captions unavailable"></bp-button-captions>
+    </div>
+  `;
+}
+
+export function readonly() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/button-captions.js';
+    </script>
+
+    <div bp-layout="inline gap:lg">
+      <bp-button-captions readonly aria-label="enable captions"></bp-button-captions>
+      <bp-button-captions checked readonly aria-label="disable captions"></bp-button-captions>
+    </div>
+  `;
+}
+
+export function form() {
+  return /* html */`
+    <form id="captions-form" bp-layout="block gap:md">
+      <bp-field>
+        <label>Captions</label>
+        <bp-button-captions name="captions-enabled" aria-label="enable captions"></bp-button-captions>
+      </bp-field>
+      <span bp-layout="block:center">false</span>
+      <bp-button type="submit" action="secondary">Submit</bp-button>
+    </form>
+    <script type="module">
+      import '@blueprintui/components/include/button-captions.js';
+      const button = document.querySelector('#captions-form bp-button-captions');
+      const form = document.querySelector('#captions-form');
+      button.addEventListener('change', (e) => document.querySelector('#captions-form span').innerHTML = e.target.checked);
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        console.log('submit', Object.fromEntries(new FormData(form)));
+      });
+    </script>
+  `;
+}
+
+export function videoPlayer() {
+  return /* html */`
+    <div bp-layout="block gap:md" style="max-width: 600px;">
+      <div style="background: var(--bp-layer-background-200); aspect-ratio: 16/9; border-radius: var(--bp-border-radius-200); display: flex; align-items: center; justify-content: center;">
+        <bp-text>Video Player</bp-text>
+      </div>
+      <div bp-layout="inline gap:md">
+        <bp-button-captions id="video-captions" aria-label="enable captions"></bp-button-captions>
+        <bp-text id="captions-status">Captions: Off</bp-text>
+      </div>
+    </div>
+    <script type="module">
+      import '@blueprintui/components/include/button-captions.js';
+      const button = document.querySelector('#video-captions');
+      const status = document.querySelector('#captions-status');
+      button.addEventListener('change', (e) => {
+        status.textContent = e.target.checked ? 'Captions: On' : 'Captions: Off';
+      });
+    </script>
+  `;
+}
+
+export function customValue() {
+  return /* html */`
+    <form id="custom-value-form" bp-layout="block gap:md">
+      <bp-button-captions
+        name="subtitles"
+        value="enabled"
+        aria-label="enable captions">
+      </bp-button-captions>
+      <span bp-layout="block:center">Form data: {}</span>
+      <bp-button type="submit" action="secondary">Check Form Data</bp-button>
+    </form>
+    <script type="module">
+      import '@blueprintui/components/include/button-captions.js';
+      const form = document.querySelector('#custom-value-form');
+      const button = form.querySelector('bp-button-captions');
+      const output = form.querySelector('span');
+
+      button.addEventListener('change', (e) => {
+        const formData = new FormData(form);
+        output.textContent = 'Form data: ' + JSON.stringify(Object.fromEntries(formData));
+      });
+
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        console.log('submit', Object.fromEntries(new FormData(form)));
+      });
+    </script>
+  `;
+}

--- a/projects/components/src/button-captions/element.performance.ts
+++ b/projects/components/src/button-captions/element.performance.ts
@@ -1,0 +1,16 @@
+import { testBundleSize, testRenderTime, html } from 'web-test-runner-performance/browser.js';
+import '@blueprintui/components/include/button-captions.js';
+
+describe('bp-button-captions performance', () => {
+  const element = html`<bp-button-captions aria-label="enable captions"></bp-button-captions>`;
+
+  it(`should bundle and treeshake under 11.5kb`, async () => {
+    expect(
+      (await testBundleSize('@blueprintui/components/include/button-captions.js', { optimize: true })).kb
+    ).toBeLessThan(11.5);
+  });
+
+  it(`should render under 20ms`, async () => {
+    expect((await testRenderTime(element)).duration).toBeLessThan(20);
+  });
+});

--- a/projects/components/src/button-captions/element.spec.ts
+++ b/projects/components/src/button-captions/element.spec.ts
@@ -1,0 +1,263 @@
+import { html } from 'lit';
+import '@blueprintui/components/include/button-captions.js';
+import { BpButtonCaptions } from '@blueprintui/components/button-captions';
+import { elementIsStable, createFixture, removeFixture } from '@blueprintui/test';
+
+describe('button-captions element', () => {
+  let fixture: HTMLElement;
+  let element: BpButtonCaptions;
+
+  beforeEach(async () => {
+    fixture = await createFixture(html`<bp-button-captions></bp-button-captions>`);
+    element = fixture.querySelector<BpButtonCaptions>('bp-button-captions');
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('should create the component', async () => {
+    await elementIsStable(element);
+    expect(customElements.get('bp-button-captions')).toBe(BpButtonCaptions);
+  });
+
+  it('should set a default ariaLabel', async () => {
+    await elementIsStable(element);
+    expect(element._internals.ariaLabel).toBe('captions');
+  });
+
+  it('should set role of button', async () => {
+    await elementIsStable(element);
+    expect(element._internals.role).toBe('button');
+  });
+
+  it('should set aria-pressed to false by default', async () => {
+    await elementIsStable(element);
+    expect(element._internals.ariaPressed).toBe('false');
+  });
+
+  it('should set aria-pressed to true when checked', async () => {
+    element.checked = true;
+    await elementIsStable(element);
+    expect(element._internals.ariaPressed).toBe('true');
+  });
+
+  it('should have default value of "on"', async () => {
+    await elementIsStable(element);
+    expect(element.value).toBe('on');
+  });
+
+  it('should reflect value to attribute', async () => {
+    await elementIsStable(element);
+    expect(element.getAttribute('value')).toBe('on');
+
+    element.value = 'custom';
+    await elementIsStable(element);
+    expect(element.getAttribute('value')).toBe('custom');
+  });
+
+  it('should support checked attribute', async () => {
+    element.checked = true;
+    await elementIsStable(element);
+    expect(element.checked).toBe(true);
+    expect(element.hasAttribute('checked')).toBe(true);
+  });
+
+  it('should display captions icon', async () => {
+    await elementIsStable(element);
+    const icon = element.shadowRoot.querySelector('bp-icon');
+
+    expect(icon).toBeTruthy();
+    expect(icon.shape).toBe('captions');
+    expect(icon.size).toBe('sm');
+  });
+
+  it('should display solid icon when checked', async () => {
+    element.checked = true;
+    await elementIsStable(element);
+    const icon = element.shadowRoot.querySelector('bp-icon');
+
+    expect(icon.type).toBe('solid');
+  });
+
+  it('should display outline icon when unchecked', async () => {
+    await elementIsStable(element);
+    const icon = element.shadowRoot.querySelector('bp-icon');
+
+    expect(icon.type).toBe('');
+  });
+
+  it('should not have a tabindex if disabled', async () => {
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(0);
+
+    element.disabled = true;
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(-1);
+
+    element.disabled = false;
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(0);
+  });
+
+  it('should not have a tabindex if readonly', async () => {
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(0);
+
+    element.readonly = true;
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(-1);
+
+    element.readonly = false;
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(0);
+  });
+
+  it('should support disabled state', async () => {
+    element.disabled = true;
+    await elementIsStable(element);
+
+    expect(element.disabled).toBe(true);
+    expect(element.matches(':state(disabled)')).toBe(true);
+  });
+
+  it('should support readonly state', async () => {
+    element.readonly = true;
+    await elementIsStable(element);
+
+    expect(element.readonly).toBe(true);
+    expect(element.matches(':state(readonly)')).toBe(true);
+  });
+
+  it('should have default i18n from I18nService', async () => {
+    await elementIsStable(element);
+    expect(element.i18n).toBeDefined();
+    expect(typeof element.i18n.captions).toBe('string');
+  });
+
+  it('should support custom i18n', async () => {
+    const customI18n = { captions: 'Custom Captions Text' };
+    element.i18n = customI18n;
+    await elementIsStable(element);
+    expect(element.i18n.captions).toBe('Custom Captions Text');
+  });
+
+  it('should support custom slot content', async () => {
+    element.innerHTML = '<bp-icon shape="custom" size="sm"></bp-icon>';
+    await elementIsStable(element);
+
+    const slot = element.shadowRoot.querySelector('slot');
+    const assignedElements = slot.assignedElements();
+
+    expect(assignedElements.length).toBe(1);
+    expect(assignedElements[0].tagName.toLowerCase()).toBe('bp-icon');
+    expect(assignedElements[0].getAttribute('shape')).toBe('custom');
+  });
+
+  it('should be form associated', async () => {
+    await elementIsStable(element);
+    expect(BpButtonCaptions.formAssociated).toBe(true);
+  });
+
+  it('should participate in forms when name is provided', async () => {
+    const formFixture = await createFixture(html`
+      <form>
+        <bp-button-captions name="captions" value="enabled"></bp-button-captions>
+      </form>
+    `);
+    const formElement = formFixture.querySelector<BpButtonCaptions>('bp-button-captions');
+    const form = formFixture.querySelector('form');
+
+    await elementIsStable(formElement);
+    formElement.checked = true;
+    await elementIsStable(formElement);
+
+    const formData = new FormData(form);
+    expect(formData.get('captions')).toBe('enabled');
+
+    formElement.checked = false;
+    await elementIsStable(formElement);
+
+    const formData2 = new FormData(form);
+    expect(formData2.get('captions')).toBeNull();
+
+    removeFixture(formFixture);
+  });
+
+  it('should have correct icon properties', async () => {
+    await elementIsStable(element);
+    const icon = element.shadowRoot.querySelector('bp-icon');
+
+    expect(icon.getAttribute('role')).toBe('presentation');
+    expect(icon.getAttribute('shape')).toBe('captions');
+    expect(icon.getAttribute('size')).toBe('sm');
+  });
+
+  it('should toggle checked state on click', async () => {
+    await elementIsStable(element);
+    expect(element.checked).toBeFalsy();
+
+    element.click();
+    await elementIsStable(element);
+    expect(element.checked).toBe(true);
+
+    element.click();
+    await elementIsStable(element);
+    expect(element.checked).toBe(false);
+  });
+
+  it('should not toggle when disabled', async () => {
+    element.disabled = true;
+    await elementIsStable(element);
+    expect(element.checked).toBeFalsy();
+
+    element.click();
+    await elementIsStable(element);
+    expect(element.checked).toBeFalsy();
+  });
+
+  it('should not toggle when readonly', async () => {
+    element.readonly = true;
+    await elementIsStable(element);
+    expect(element.checked).toBeFalsy();
+
+    element.click();
+    await elementIsStable(element);
+    expect(element.checked).toBeFalsy();
+  });
+
+  it('should fire change event on user interaction', async () => {
+    await elementIsStable(element);
+    const changeSpy = jasmine.createSpy('change');
+    element.addEventListener('change', changeSpy);
+
+    element.click();
+    await elementIsStable(element);
+
+    expect(changeSpy).toHaveBeenCalled();
+  });
+
+  it('should fire input event on user interaction', async () => {
+    await elementIsStable(element);
+    const inputSpy = jasmine.createSpy('input');
+    element.addEventListener('input', inputSpy);
+
+    element.click();
+    await elementIsStable(element);
+
+    expect(inputSpy).toHaveBeenCalled();
+  });
+
+  it('should accept custom aria-label', async () => {
+    element.setAttribute('aria-label', 'enable captions');
+    await elementIsStable(element);
+    expect(element.getAttribute('aria-label')).toBe('enable captions');
+  });
+
+  it('should support custom value attribute', async () => {
+    element.value = 'custom-value';
+    await elementIsStable(element);
+    expect(element.value).toBe('custom-value');
+    expect(element.getAttribute('value')).toBe('custom-value');
+  });
+});

--- a/projects/components/src/button-captions/element.ts
+++ b/projects/components/src/button-captions/element.ts
@@ -1,0 +1,95 @@
+import { html, LitElement, PropertyValues } from 'lit';
+import { property } from 'lit/decorators/property.js';
+import {
+  baseStyles,
+  i18n,
+  I18nService,
+  I18nStrings,
+  interactionClick,
+  interactionStyles,
+  stateActive
+} from '@blueprintui/components/internals';
+import { typeFormCheckbox, typeFormControl, TypeFormControl } from '@blueprintui/components/forms';
+import styles from './element.css' with { type: 'css' };
+
+export interface BpButtonCaptions extends TypeFormControl {} // eslint-disable-line
+
+/**
+ * ```typescript
+ * import '@blueprintui/components/include/button-captions.js';
+ * ```
+ *
+ * ```html
+ * <bp-button-captions aria-label="enable captions"></bp-button-captions>
+ * ```
+ *
+ * @summary The button captions component provides a toggle control for closed captioning and subtitle display.
+ * @element bp-button-captions
+ * @since 2.10.0
+ * @slot - slot for custom bp-icon
+ * @cssprop --background
+ * @cssprop --color
+ * @cssprop --border-color
+ * @cssprop --border-radius
+ * @cssprop --padding
+ * @cssprop --background-hover
+ * @cssprop --background-pressed
+ * @cssprop --color-pressed
+ * @cssprop --border-color-pressed
+ * @event {InputEvent} input - occurs when the value changes
+ * @event {InputEvent} change - occurs when the value changes
+ */
+@stateActive<BpButtonCaptions>()
+@typeFormControl<BpButtonCaptions>()
+@interactionClick<BpButtonCaptions>()
+@i18n<BpButtonCaptions>({ key: 'actions' })
+@typeFormCheckbox<BpButtonCaptions>({ requireName: false })
+export class BpButtonCaptions
+  extends LitElement
+  implements Pick<BpButtonCaptions, 'value' | 'checked' | 'readonly' | 'disabled' | 'i18n'>
+{
+  /** determines initial value of the control */
+  @property({ type: String, reflect: true }) accessor value = 'on';
+
+  /** determines whether element is checked (captions on) */
+  @property({ type: Boolean }) accessor checked: boolean;
+
+  @property({ type: Boolean }) accessor readonly: boolean;
+
+  /** determines if element is mutable or focusable */
+  @property({ type: Boolean }) accessor disabled: boolean;
+
+  /** represents the name of the current <form> element as a string. */
+  declare name: string;
+
+  @property({ type: Object }) accessor i18n: I18nStrings['actions'] = I18nService.keys.actions;
+
+  static formAssociated = true;
+
+  static styles = [baseStyles, interactionStyles, styles];
+
+  render() {
+    return html`
+      <div part="button" interaction-after>
+        <div part="icon">
+          <slot>
+            <bp-icon role="presentation" shape="captions" size="sm" .type=${this.checked ? 'solid' : ''}> </bp-icon>
+          </slot>
+        </div>
+      </div>
+    `;
+  }
+
+  firstUpdated(props: PropertyValues<this>) {
+    super.firstUpdated(props);
+    this._internals.role = 'button';
+    this._internals.ariaLabel ??= this.i18n.captions;
+  }
+
+  updated(props: PropertyValues<this>) {
+    super.updated(props);
+    if (props.has('checked')) {
+      this._internals.ariaPressed = this.checked ? 'true' : 'false';
+    }
+  }
+}

--- a/projects/components/src/button-captions/element.visual.ts
+++ b/projects/components/src/button-captions/element.visual.ts
@@ -1,0 +1,33 @@
+import { html } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { visualDiff } from '@web/test-runner-visual-regression';
+import { createVisualFixture, removeFixture } from '@blueprintui/test';
+import * as buttonCaptions from './element.examples.js';
+import '@blueprintui/components/include/button-captions.js';
+
+describe('bp-button-captions', () => {
+  let fixture: HTMLElement;
+
+  beforeEach(async () => {
+    fixture = await createVisualFixture(
+      html`
+        ${unsafeHTML(buttonCaptions.example())} ${unsafeHTML(buttonCaptions.checked())}
+        ${unsafeHTML(buttonCaptions.disabled())} ${unsafeHTML(buttonCaptions.readonly())}
+      `,
+      { width: '800px', height: '300px' }
+    );
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('light theme', async () => {
+    await visualDiff(fixture, 'button-captions/light.png');
+  });
+
+  it('dark theme', async () => {
+    document.documentElement.setAttribute('bp-theme', 'dark');
+    await visualDiff(fixture, 'button-captions/dark.png');
+  });
+});

--- a/projects/components/src/button-captions/index.ts
+++ b/projects/components/src/button-captions/index.ts
@@ -1,0 +1,1 @@
+export * from './element.js';

--- a/projects/components/src/include/all.ts
+++ b/projects/components/src/include/all.ts
@@ -2,6 +2,7 @@ import '@blueprintui/components/include/accordion.js';
 import '@blueprintui/components/include/alert.js';
 import '@blueprintui/components/include/badge.js';
 import '@blueprintui/components/include/breadcrumb.js';
+import '@blueprintui/components/include/button-captions.js';
 import '@blueprintui/components/include/button-expand.js';
 import '@blueprintui/components/include/button-group.js';
 import '@blueprintui/components/include/button-handle.js';

--- a/projects/components/src/include/button-captions.ts
+++ b/projects/components/src/include/button-captions.ts
@@ -1,0 +1,12 @@
+import '@blueprintui/icons/include.js';
+import '@blueprintui/icons/shapes/captions.js';
+import { defineElement } from '@blueprintui/components/internals';
+import { BpButtonCaptions } from '@blueprintui/components/button-captions';
+
+defineElement('bp-button-captions', BpButtonCaptions);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'bp-button-captions': BpButtonCaptions;
+  }
+}

--- a/projects/components/src/include/lazy.ts
+++ b/projects/components/src/include/lazy.ts
@@ -3,6 +3,7 @@ export const loader = {
   alert: () => import('@blueprintui/components/include/alert.js'),
   badge: () => import('@blueprintui/components/include/badge.js'),
   breadcrumb: () => import('@blueprintui/components/include/breadcrumb.js'),
+  'button-captions': () => import('@blueprintui/components/include/button-captions.js'),
   'button-expand': () => import('@blueprintui/components/include/button-expand.js'),
   'button-group': () => import('@blueprintui/components/include/button-group.js'),
   'button-handle': () => import('@blueprintui/components/include/button-handle.js'),

--- a/projects/components/src/internals/services/i18n.service.ts
+++ b/projects/components/src/internals/services/i18n.service.ts
@@ -32,6 +32,7 @@ export interface I18nStrings {
     nextPage: string;
     lastPage: string;
     pageSize: string;
+    captions: string;
   };
 }
 
@@ -65,7 +66,8 @@ export const i18nRegistry: I18nStrings = {
     previousPage: 'go to previous page',
     nextPage: 'go to next page',
     lastPage: 'go to last page',
-    pageSize: 'items per page'
+    pageSize: 'items per page',
+    captions: 'captions'
   }
 };
 


### PR DESCRIPTION
Implement the button-captions component as a toggle control for closed captioning and subtitle display. The component functions as a form control with checkbox-like boolean state behavior, suitable for video players, media applications, and accessibility-focused interfaces.

Component features:
- Toggle button with checked/unchecked states for captions on/off
- Form integration with name and value attributes
- Disabled and readonly state support
- CSS custom properties for theming
- Comprehensive test coverage (unit, visual, performance)
- Accessibility support with ARIA attributes (role=button, aria-pressed)
- i18n support with customizable labels
- Design token-based styling

Files added:
- All 7 required component files (element.ts, .css, .spec.ts, .visual.ts, .performance.ts, .examples.js, index.ts)
- Registration in include/button-captions.ts
- Integration with include/all.ts and include/lazy.ts

Also adds 'captions' key to i18n service for default aria-label.