### PR TITLE
bp-button-mute

### DIFF
--- a/projects/components/src/button-mute/element.css
+++ b/projects/components/src/button-mute/element.css
@@ -1,0 +1,79 @@
+:host {
+  --background: var(--bp-layer-background-100);
+  --color: var(--bp-text-200);
+  --border-color: var(--bp-border-200);
+  --border-radius: var(--bp-border-radius-100);
+  --padding: var(--bp-spacing-100);
+  --background-hover: var(--bp-layer-background-200);
+  --background-pressed: var(--bp-layer-background-200);
+  --color-pressed: var(--bp-danger-600);
+  --border-color-pressed: var(--bp-danger-600);
+  --width: fit-content;
+  --height: fit-content;
+  --bp-interaction-offset: 0;
+  --opacity: 1;
+  width: var(--width);
+  height: var(--height);
+  opacity: var(--opacity);
+  display: inline-flex;
+}
+
+:host(:state(disabled)) {
+  --background: transparent;
+  --bp-interaction-offset: 0;
+  --opacity: 0.4;
+  --cursor: default;
+}
+
+:host(:state(readonly)) {
+  --background: transparent;
+  --bp-interaction-offset: 0;
+  --pointer-events: none;
+}
+
+:host(:hover:not(:state(disabled)):not(:state(readonly))) {
+  --background: var(--background-hover);
+}
+
+:host([checked]) {
+  --background: var(--background-pressed);
+  --color: var(--color-pressed);
+  --border-color: var(--border-color-pressed);
+}
+
+[part='button'] {
+  width: var(--width);
+  height: var(--height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--background);
+  border: var(--bp-size-1) solid var(--border-color);
+  border-radius: var(--border-radius);
+  padding: var(--padding);
+  cursor: var(--cursor);
+}
+
+[part='button']::after {
+  content: '';
+  position: absolute;
+  left: calc(calc(-1 * var(--width)) - 1);
+  top: calc(calc(-1 * var(--height)) - 1);
+  width: var(--bp-interaction-touch-target);
+  height: var(--bp-interaction-touch-target);
+  border-radius: var(--border-radius);
+  z-index: -1;
+}
+
+[part='icon'] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color);
+}
+
+bp-icon,
+::slotted(bp-icon) {
+  --color: inherit;
+  cursor: var(--cursor) !important;
+}

--- a/projects/components/src/button-mute/element.examples.js
+++ b/projects/components/src/button-mute/element.examples.js
@@ -1,0 +1,103 @@
+export const metadata = {
+  name: 'button-mute',
+  elements: ['bp-button-mute']
+};
+
+export function example() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/button-mute.js';
+    </script>
+
+    <div bp-layout="inline gap:lg">
+      <bp-button-mute aria-label="mute audio"></bp-button-mute>
+    </div>
+  `;
+}
+
+export function checked() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/button-mute.js';
+    </script>
+
+    <div bp-layout="inline gap:lg">
+      <bp-button-mute checked aria-label="unmute audio"></bp-button-mute>
+    </div>
+  `;
+}
+
+export function disabled() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/button-mute.js';
+    </script>
+
+    <div bp-layout="inline gap:lg">
+      <bp-button-mute disabled aria-label="mute audio"></bp-button-mute>
+      <bp-button-mute disabled checked aria-label="unmute audio"></bp-button-mute>
+    </div>
+  `;
+}
+
+export function readonly() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/button-mute.js';
+    </script>
+
+    <div bp-layout="inline gap:lg">
+      <bp-button-mute readonly aria-label="mute audio"></bp-button-mute>
+      <bp-button-mute readonly checked aria-label="unmute audio"></bp-button-mute>
+    </div>
+  `;
+}
+
+export function form() {
+  return /* html */`
+    <form id="mute-button-form" bp-layout="block gap:md">
+      <bp-field>
+        <label>Audio Controls</label>
+        <bp-button-mute name="audio-muted" aria-label="mute audio"></bp-button-mute>
+      </bp-field>
+      <span bp-layout="block:center" id="mute-status">unmuted</span>
+      <bp-button type="submit" action="secondary">Submit</bp-button>
+    </form>
+    <script type="module">
+      import '@blueprintui/components/include/button-mute.js';
+      const button = document.querySelector('#mute-button-form bp-button-mute');
+      const form = document.querySelector('#mute-button-form');
+      const status = document.querySelector('#mute-status');
+
+      button.addEventListener('change', (e) => {
+        status.innerHTML = e.target.checked ? 'muted' : 'unmuted';
+        e.target.setAttribute('aria-label', e.target.checked ? 'unmute audio' : 'mute audio');
+      });
+
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        console.log('submit', Object.fromEntries(new FormData(form)));
+      });
+    </script>
+  `;
+}
+
+export function customValue() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/button-mute.js';
+    </script>
+
+    <form id="custom-value-form" bp-layout="block gap:md">
+      <bp-button-mute name="volume" value="muted" aria-label="mute audio"></bp-button-mute>
+      <bp-button type="submit" action="secondary">Submit</bp-button>
+    </form>
+    <script type="module">
+      const form = document.querySelector('#custom-value-form');
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        console.log('Form data:', Object.fromEntries(new FormData(form)));
+      });
+    </script>
+  `;
+}

--- a/projects/components/src/button-mute/element.performance.ts
+++ b/projects/components/src/button-mute/element.performance.ts
@@ -1,0 +1,16 @@
+import { testBundleSize, testRenderTime, html } from 'web-test-runner-performance/browser.js';
+import '@blueprintui/components/include/button-mute.js';
+
+describe('bp-button-mute performance', () => {
+  const element = html`<bp-button-mute></bp-button-mute>`;
+
+  it(`should bundle and treeshake under 11.5kb`, async () => {
+    expect(
+      (await testBundleSize('@blueprintui/components/include/button-mute.js', { optimize: true })).kb
+    ).toBeLessThan(11.5);
+  });
+
+  it(`should render under 20ms`, async () => {
+    expect((await testRenderTime(element)).duration).toBeLessThan(20);
+  });
+});

--- a/projects/components/src/button-mute/element.spec.ts
+++ b/projects/components/src/button-mute/element.spec.ts
@@ -1,0 +1,225 @@
+import { html } from 'lit';
+import '@blueprintui/components/include/button-mute.js';
+import { BpButtonMute } from '@blueprintui/components/button-mute';
+import { elementIsStable, createFixture, removeFixture } from '@blueprintui/test';
+
+describe('button-mute element', () => {
+  let fixture: HTMLElement;
+  let element: BpButtonMute;
+
+  beforeEach(async () => {
+    fixture = await createFixture(html`<bp-button-mute name="audio-muted"></bp-button-mute>`);
+    element = fixture.querySelector<BpButtonMute>('bp-button-mute');
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('should create the component', async () => {
+    await elementIsStable(element);
+    expect(customElements.get('bp-button-mute')).toBe(BpButtonMute);
+  });
+
+  it('should set a default ariaLabel', async () => {
+    await elementIsStable(element);
+    expect(element._internals.ariaLabel).toBe('mute');
+  });
+
+  it('should set role of button', async () => {
+    await elementIsStable(element);
+    expect(element._internals.role).toBe('button');
+  });
+
+  it('should have default value of "on"', async () => {
+    await elementIsStable(element);
+    expect(element.value).toBe('on');
+  });
+
+  it('should reflect value to attribute', async () => {
+    await elementIsStable(element);
+    expect(element.getAttribute('value')).toBe('on');
+
+    element.value = 'muted';
+    await elementIsStable(element);
+    expect(element.getAttribute('value')).toBe('muted');
+  });
+
+  it('should display unmuted icon by default', async () => {
+    await elementIsStable(element);
+    const icon = element.shadowRoot.querySelector('bp-icon');
+
+    expect(element.checked).toBeFalsy();
+    expect(icon.shape).toBe('volume');
+    expect(icon.size).toBe('md');
+  });
+
+  it('should display muted icon when checked', async () => {
+    element.checked = true;
+    await elementIsStable(element);
+    const icon = element.shadowRoot.querySelector('bp-icon');
+
+    expect(element.checked).toBe(true);
+    expect(icon.shape).toBe('volume-mute');
+    expect(icon.size).toBe('md');
+  });
+
+  it('should toggle checked state on click', async () => {
+    await elementIsStable(element);
+    expect(element.checked).toBeFalsy();
+
+    element.click();
+    await elementIsStable(element);
+    expect(element.checked).toBe(true);
+
+    element.click();
+    await elementIsStable(element);
+    expect(element.checked).toBe(false);
+  });
+
+  it('should not have a tabindex if disabled', async () => {
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(0);
+
+    element.disabled = true;
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(-1);
+
+    element.disabled = false;
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(0);
+  });
+
+  it('should not have a tabindex if readonly', async () => {
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(0);
+
+    element.readonly = true;
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(-1);
+  });
+
+  it('should support disabled state', async () => {
+    await elementIsStable(element);
+    expect(element.matches(':state(disabled)')).toBe(false);
+
+    element.disabled = true;
+    await elementIsStable(element);
+    expect(element.matches(':state(disabled)')).toBe(true);
+    expect(element.tabIndex).toBe(-1);
+  });
+
+  it('should support readonly state', async () => {
+    await elementIsStable(element);
+    expect(element.matches(':state(readonly)')).toBe(false);
+
+    element.readonly = true;
+    await elementIsStable(element);
+    expect(element.matches(':state(readonly)')).toBe(true);
+    expect(element.tabIndex).toBe(-1);
+  });
+
+  it('should not toggle when disabled', async () => {
+    element.disabled = true;
+    await elementIsStable(element);
+
+    element.click();
+    await elementIsStable(element);
+    expect(element.checked).toBeFalsy();
+  });
+
+  it('should not toggle when readonly', async () => {
+    element.readonly = true;
+    await elementIsStable(element);
+
+    element.click();
+    await elementIsStable(element);
+    expect(element.checked).toBeFalsy();
+  });
+
+  it('should have default i18n from I18nService', async () => {
+    await elementIsStable(element);
+    expect(element.i18n).toBeDefined();
+    expect(typeof element.i18n.mute).toBe('string');
+  });
+
+  it('should support custom i18n', async () => {
+    const customI18n = { mute: 'Custom Mute Text' };
+    element.i18n = customI18n;
+    await elementIsStable(element);
+    expect(element.i18n.mute).toBe('Custom Mute Text');
+  });
+
+  it('should support custom slot content', async () => {
+    element.innerHTML = '<bp-icon shape="bell" size="md"></bp-icon>';
+    await elementIsStable(element);
+
+    const slot = element.shadowRoot.querySelector('slot');
+    const assignedElements = slot.assignedElements();
+
+    expect(assignedElements.length).toBe(1);
+    expect(assignedElements[0].tagName.toLowerCase()).toBe('bp-icon');
+    expect(assignedElements[0].getAttribute('shape')).toBe('bell');
+  });
+
+  it('should be form associated', async () => {
+    await elementIsStable(element);
+    expect(element._internals.form).toBeNull(); // No form in test fixture
+    expect(BpButtonMute.formAssociated).toBe(true);
+  });
+
+  it('should have name property', async () => {
+    await elementIsStable(element);
+    expect(element.name).toBe('audio-muted');
+  });
+
+  it('should have correct icon properties', async () => {
+    await elementIsStable(element);
+    const icon = element.shadowRoot.querySelector('bp-icon');
+
+    expect(icon.getAttribute('role')).toBe('presentation');
+    expect(icon.getAttribute('shape')).toBe('volume');
+    expect(icon.getAttribute('size')).toBe('md');
+  });
+
+  it('should reflect checked to attribute', async () => {
+    await elementIsStable(element);
+    expect(element.hasAttribute('checked')).toBe(false);
+
+    element.checked = true;
+    await elementIsStable(element);
+    expect(element.hasAttribute('checked')).toBe(true);
+
+    element.checked = false;
+    await elementIsStable(element);
+    expect(element.hasAttribute('checked')).toBe(false);
+  });
+
+  it('should fire change event on click', async () => {
+    await elementIsStable(element);
+    let changeEventFired = false;
+
+    element.addEventListener('change', () => {
+      changeEventFired = true;
+    });
+
+    element.click();
+    await elementIsStable(element);
+
+    expect(changeEventFired).toBe(true);
+  });
+
+  it('should fire input event on click', async () => {
+    await elementIsStable(element);
+    let inputEventFired = false;
+
+    element.addEventListener('input', () => {
+      inputEventFired = true;
+    });
+
+    element.click();
+    await elementIsStable(element);
+
+    expect(inputEventFired).toBe(true);
+  });
+});

--- a/projects/components/src/button-mute/element.ts
+++ b/projects/components/src/button-mute/element.ts
@@ -1,0 +1,90 @@
+import { html, LitElement, PropertyValues } from 'lit';
+import { property } from 'lit/decorators/property.js';
+import {
+  baseStyles,
+  i18n,
+  I18nService,
+  I18nStrings,
+  interactionClick,
+  interactionStyles,
+  stateActive
+} from '@blueprintui/components/internals';
+import { typeFormCheckbox, typeFormControl, TypeFormControl } from '@blueprintui/components/forms';
+import styles from './element.css' with { type: 'css' };
+
+export interface BpButtonMute extends TypeFormControl {} // eslint-disable-line
+
+/**
+ * ```typescript
+ * import '@blueprintui/components/include/button-mute.js';
+ * ```
+ *
+ * ```html
+ * <bp-button-mute aria-label="mute audio"></bp-button-mute>
+ * ```
+ *
+ * @summary The button mute component provides a toggle control for audio mute states.
+ * @element bp-button-mute
+ * @since 2.11.0
+ * @slot - slot for custom bp-icon
+ * @cssprop --background
+ * @cssprop --color
+ * @cssprop --border-color
+ * @cssprop --border-radius
+ * @cssprop --padding
+ * @cssprop --background-hover
+ * @cssprop --background-pressed
+ * @cssprop --color-pressed
+ * @cssprop --border-color-pressed
+ * @event {InputEvent} input - occurs when the value changes
+ * @event {Event} change - occurs when the value changes
+ */
+@stateActive<BpButtonMute>()
+@typeFormControl<BpButtonMute>()
+@interactionClick<BpButtonMute>()
+@i18n<BpButtonMute>({ key: 'actions' })
+@typeFormCheckbox<BpButtonMute>({ requireName: true })
+export class BpButtonMute
+  extends LitElement
+  implements Pick<BpButtonMute, 'value' | 'checked' | 'readonly' | 'disabled' | 'i18n'>
+{
+  /** determines initial value of the control */
+  @property({ type: String, reflect: true }) accessor value = 'on';
+
+  /** determines whether element is checked (muted) */
+  @property({ type: Boolean }) accessor checked: boolean;
+
+  @property({ type: Boolean }) accessor readonly: boolean;
+
+  /** determines if element is mutable or focusable */
+  @property({ type: Boolean }) accessor disabled: boolean;
+
+  /** represents the name of the current <form> element as a string. */
+  declare name: string;
+
+  @property({ type: Object }) accessor i18n: I18nStrings['actions'] = I18nService.keys.actions;
+
+  static formAssociated = true;
+
+  static styles = [baseStyles, interactionStyles, styles];
+
+  render() {
+    return html`
+      <div part="button" interaction-after>
+        <div part="icon">
+          <slot>
+            ${this.checked
+              ? html`<bp-icon role="presentation" shape="volume-mute" size="md"></bp-icon>`
+              : html`<bp-icon role="presentation" shape="volume" size="md"></bp-icon>`}
+          </slot>
+        </div>
+      </div>
+    `;
+  }
+
+  firstUpdated(props: PropertyValues<this>) {
+    super.firstUpdated(props);
+    this._internals.role = 'button';
+    this._internals.ariaLabel ??= this.i18n.mute;
+  }
+}

--- a/projects/components/src/button-mute/element.visual.ts
+++ b/projects/components/src/button-mute/element.visual.ts
@@ -1,0 +1,33 @@
+import { html } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { visualDiff } from '@web/test-runner-visual-regression';
+import { createVisualFixture, removeFixture } from '@blueprintui/test';
+import * as buttonMute from './element.examples.js';
+import '@blueprintui/components/include/button-mute.js';
+
+describe('bp-button-mute', () => {
+  let fixture: HTMLElement;
+
+  beforeEach(async () => {
+    fixture = await createVisualFixture(
+      html`
+        ${unsafeHTML(buttonMute.example())} ${unsafeHTML(buttonMute.checked())} ${unsafeHTML(buttonMute.disabled())}
+        ${unsafeHTML(buttonMute.readonly())}
+      `,
+      { width: '800px', height: '300px' }
+    );
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('light theme', async () => {
+    await visualDiff(fixture, 'button-mute/light.png');
+  });
+
+  it('dark theme', async () => {
+    document.documentElement.setAttribute('bp-theme', 'dark');
+    await visualDiff(fixture, 'button-mute/dark.png');
+  });
+});

--- a/projects/components/src/button-mute/index.ts
+++ b/projects/components/src/button-mute/index.ts
@@ -1,0 +1,1 @@
+export * from './element.js';

--- a/projects/components/src/include/all.ts
+++ b/projects/components/src/include/all.ts
@@ -7,6 +7,7 @@ import '@blueprintui/components/include/button-expand.js';
 import '@blueprintui/components/include/button-group.js';
 import '@blueprintui/components/include/button-handle.js';
 import '@blueprintui/components/include/button-icon.js';
+import '@blueprintui/components/include/button-mute.js';
 import '@blueprintui/components/include/button-sort.js';
 import '@blueprintui/components/include/button.js';
 import '@blueprintui/components/include/card.js';

--- a/projects/components/src/include/button-mute.ts
+++ b/projects/components/src/include/button-mute.ts
@@ -1,0 +1,13 @@
+import '@blueprintui/icons/include.js';
+import '@blueprintui/icons/shapes/volume.js';
+import '@blueprintui/icons/shapes/volume-mute.js';
+import { defineElement } from '@blueprintui/components/internals';
+import { BpButtonMute } from '@blueprintui/components/button-mute';
+
+defineElement('bp-button-mute', BpButtonMute);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'bp-button-mute': BpButtonMute;
+  }
+}

--- a/projects/components/src/include/lazy.ts
+++ b/projects/components/src/include/lazy.ts
@@ -7,6 +7,7 @@ export const loader = {
   'button-group': () => import('@blueprintui/components/include/button-group.js'),
   'button-handle': () => import('@blueprintui/components/include/button-handle.js'),
   'button-icon': () => import('@blueprintui/components/include/button-icon.js'),
+  'button-mute': () => import('@blueprintui/components/include/button-mute.js'),
   'button-sort': () => import('@blueprintui/components/include/button-sort.js'),
   button: () => import('@blueprintui/components/include/button.js'),
   card: () => import('@blueprintui/components/include/card.js'),

--- a/projects/components/src/internals/services/i18n.service.ts
+++ b/projects/components/src/internals/services/i18n.service.ts
@@ -33,6 +33,7 @@ export interface I18nStrings {
     nextPage: string;
     lastPage: string;
     pageSize: string;
+    mute: string;
   };
 }
 
@@ -67,7 +68,8 @@ export const i18nRegistry: I18nStrings = {
     previousPage: 'go to previous page',
     nextPage: 'go to next page',
     lastPage: 'go to last page',
-    pageSize: 'items per page'
+    pageSize: 'items per page',
+    mute: 'mute'
   }
 };
 


### PR DESCRIPTION
- Add new button-mute component with toggle mute/unmute functionality
- Support form participation when name attribute is provided
- Include checked, disabled, readonly, name, and value properties
- Integrate volume and volume-mute icons
- Add comprehensive unit tests, visual tests, and performance tests
- Add documentation examples including form integration
- Add 'mute' to i18n service actions
- Register component in include/all.ts and include/lazy.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `bp-button-mute` toggle with volume icons, form association, examples, tests, and new `i18n.actions.mute` key, registered in includes and lazy loader.
> 
> - **Component**:
>   - New `bp-button-mute` (`projects/components/src/button-mute/element.ts`) with styles (`element.css`), toggle icons (`volume`/`volume-mute`), form-associated checkbox behavior, and i18n-backed default aria-label.
> - **Examples**:
>   - Usage demos incl. checked/disabled/readonly, form integration, and custom value (`button-mute/element.examples.js`).
> - **Tests**:
>   - Unit (`element.spec.ts`), visual (`element.visual.ts`), and performance tests (`element.performance.ts`).
> - **Registration**:
>   - Export and define element (`button-mute/index.ts`, `include/button-mute.ts`), added to `include/all.ts` and `include/lazy.ts`.
> - **i18n**:
>   - Add `actions.mute` key to `i18n.service.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca55c088ba9ab20c38280ee13c874e723a32a905. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->