### PR TITLE
bp-button-play

### DIFF
--- a/projects/components/src/button-play/element.css
+++ b/projects/components/src/button-play/element.css
@@ -1,0 +1,58 @@
+:host {
+  --background: var(--bp-layer-background-100);
+  --color: var(--bp-text-200);
+  --border-color: var(--bp-border-200);
+  --border-radius: var(--bp-border-radius-100);
+  --padding: var(--bp-spacing-100);
+  --background-hover: var(--bp-layer-background-200);
+  --background-pressed: var(--bp-layer-background-200);
+  --color-pressed: var(--bp-accent-700);
+  --border-color-pressed: var(--bp-accent-700);
+  --width: fit-content;
+  --height: fit-content;
+  --bp-interaction-offset: 0;
+  display: inline-flex;
+  width: var(--width);
+  height: var(--height);
+}
+
+:host(:hover:not(:state(disabled)):not(:state(readonly))) {
+  --background: var(--background-hover);
+}
+
+:host([pressed]) {
+  --background: var(--background-pressed);
+  --color: var(--color-pressed);
+  --border-color: var(--border-color-pressed);
+}
+
+:host(:state(disabled)) {
+  --opacity: 0.4;
+  --cursor: default;
+  opacity: var(--opacity);
+}
+
+:host(:state(readonly)) {
+  --cursor: default;
+  --pointer-events: none;
+}
+
+[part='button'] {
+  background: var(--background);
+  color: var(--color);
+  border: var(--bp-size-border-100) solid var(--border-color);
+  border-radius: var(--border-radius);
+  padding: var(--padding);
+  width: var(--width);
+  height: var(--height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: var(--cursor);
+}
+
+bp-icon,
+::slotted(bp-icon) {
+  --color: inherit;
+  cursor: var(--cursor) !important;
+}

--- a/projects/components/src/button-play/element.examples.js
+++ b/projects/components/src/button-play/element.examples.js
@@ -1,0 +1,112 @@
+export const metadata = {
+  name: 'button-play',
+  elements: ['bp-button-play']
+};
+
+export function example() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/button-play.js';
+    </script>
+
+    <div bp-layout="inline gap:lg">
+      <bp-button-play aria-label="play audio"></bp-button-play>
+      <bp-button-play checked aria-label="pause audio"></bp-button-play>
+    </div>
+  `;
+}
+
+export function disabled() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/button-play.js';
+    </script>
+
+    <div bp-layout="inline gap:lg">
+      <bp-button-play disabled aria-label="play audio"></bp-button-play>
+      <bp-button-play checked disabled aria-label="pause audio"></bp-button-play>
+    </div>
+  `;
+}
+
+export function readonly() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/button-play.js';
+    </script>
+
+    <div bp-layout="inline gap:lg">
+      <bp-button-play readonly aria-label="play audio"></bp-button-play>
+      <bp-button-play checked readonly aria-label="pause audio"></bp-button-play>
+    </div>
+  `;
+}
+
+export function form() {
+  return /* html */`
+    <form id="media-form" bp-layout="block gap:md">
+      <bp-field>
+        <label>Media Playback</label>
+        <bp-button-play name="media-state" aria-label="play audio"></bp-button-play>
+      </bp-field>
+      <span bp-layout="block:center">Playing: false</span>
+      <bp-button type="submit" action="secondary">Submit</bp-button>
+    </form>
+    <script type="module">
+      import '@blueprintui/components/include/button-play.js';
+      import '@blueprintui/components/include/field.js';
+      import '@blueprintui/components/include/button.js';
+
+      const button = document.querySelector('#media-form bp-button-play');
+      const form = document.querySelector('#media-form');
+      button.addEventListener('change', (e) => {
+        document.querySelector('#media-form span').innerHTML = 'Playing: ' + e.target.checked;
+      });
+      form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        console.log('submit', Object.fromEntries(new FormData(form)));
+      });
+    </script>
+  `;
+}
+
+export function customValue() {
+  return /* html */`
+    <script type="module">
+      import '@blueprintui/components/include/button-play.js';
+    </script>
+
+    <div bp-layout="inline gap:lg">
+      <bp-button-play name="playback" value="playing" aria-label="play audio"></bp-button-play>
+    </div>
+  `;
+}
+
+export function audioPlayer() {
+  return /* html */`
+    <div class="audio-player" bp-layout="block gap:md">
+      <bp-button-play id="audio-toggle" aria-label="play audio"></bp-button-play>
+      <audio id="audio-element" src="https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3"></audio>
+    </div>
+
+    <script type="module">
+      import '@blueprintui/components/include/button-play.js';
+
+      const button = document.querySelector('#audio-toggle');
+      const audio = document.querySelector('#audio-element');
+
+      button.addEventListener('change', (e) => {
+        if (e.target.checked) {
+          audio.play();
+        } else {
+          audio.pause();
+        }
+      });
+
+      // Sync button state with audio events
+      audio.addEventListener('play', () => button.checked = true);
+      audio.addEventListener('pause', () => button.checked = false);
+      audio.addEventListener('ended', () => button.checked = false);
+    </script>
+  `;
+}

--- a/projects/components/src/button-play/element.performance.ts
+++ b/projects/components/src/button-play/element.performance.ts
@@ -1,0 +1,16 @@
+import { testBundleSize, testRenderTime, html } from 'web-test-runner-performance/browser.js';
+import '@blueprintui/components/include/button-play.js';
+
+describe('bp-button-play performance', () => {
+  const element = html`<bp-button-play></bp-button-play>`;
+
+  it(`should bundle and treeshake under 11.5kb`, async () => {
+    expect(
+      (await testBundleSize('@blueprintui/components/include/button-play.js', { optimize: true })).kb
+    ).toBeLessThan(11.5);
+  });
+
+  it(`should render under 20ms`, async () => {
+    expect((await testRenderTime(element)).duration).toBeLessThan(20);
+  });
+});

--- a/projects/components/src/button-play/element.spec.ts
+++ b/projects/components/src/button-play/element.spec.ts
@@ -1,0 +1,232 @@
+import { html } from 'lit';
+import '@blueprintui/components/include/button-play.js';
+import { BpButtonPlay } from '@blueprintui/components/button-play';
+import { elementIsStable, createFixture, removeFixture } from '@blueprintui/test';
+
+describe('button-play element', () => {
+  let fixture: HTMLElement;
+  let element: BpButtonPlay;
+
+  beforeEach(async () => {
+    fixture = await createFixture(html`<bp-button-play name="playback"></bp-button-play>`);
+    element = fixture.querySelector<BpButtonPlay>('bp-button-play');
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('should create the component', async () => {
+    await elementIsStable(element);
+    expect(customElements.get('bp-button-play')).toBe(BpButtonPlay);
+  });
+
+  it('should set a default ariaLabel for play state', async () => {
+    await elementIsStable(element);
+    expect(element._internals.ariaLabel).toBe('play');
+  });
+
+  it('should update ariaLabel when checked changes to pause', async () => {
+    await elementIsStable(element);
+    expect(element._internals.ariaLabel).toBe('play');
+
+    element.checked = true;
+    await elementIsStable(element);
+    expect(element._internals.ariaLabel).toBe('pause');
+  });
+
+  it('should set role of button', async () => {
+    await elementIsStable(element);
+    expect(element._internals.role).toBe('button');
+  });
+
+  it('should set aria-pressed based on checked state', async () => {
+    await elementIsStable(element);
+    expect(element._internals.ariaPressed).toBe('false');
+
+    element.checked = true;
+    await elementIsStable(element);
+    expect(element._internals.ariaPressed).toBe('true');
+
+    element.checked = false;
+    await elementIsStable(element);
+    expect(element._internals.ariaPressed).toBe('false');
+  });
+
+  it('should display play icon when unchecked', async () => {
+    await elementIsStable(element);
+    const icon = element.shadowRoot.querySelector('bp-icon');
+
+    expect(element.checked).toBeFalsy();
+    expect(icon.shape).toBe('play');
+    expect(icon.size).toBe('sm');
+  });
+
+  it('should display pause icon when checked', async () => {
+    element.checked = true;
+    await elementIsStable(element);
+    const icon = element.shadowRoot.querySelector('bp-icon');
+
+    expect(element.checked).toBe(true);
+    expect(icon.shape).toBe('pause');
+    expect(icon.size).toBe('sm');
+  });
+
+  it('should not have a tabindex if readonly or disabled', async () => {
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(0);
+
+    element.disabled = true;
+    await elementIsStable(element);
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(-1);
+
+    element.disabled = false;
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(0);
+
+    element.readonly = true;
+    await elementIsStable(element);
+    expect(element.tabIndex).toBe(-1);
+  });
+
+  it('should have default value of "on"', async () => {
+    await elementIsStable(element);
+    expect(element.value).toBe('on');
+  });
+
+  it('should reflect value to attribute', async () => {
+    await elementIsStable(element);
+    expect(element.getAttribute('value')).toBe('on');
+
+    element.value = 'playing';
+    await elementIsStable(element);
+    expect(element.getAttribute('value')).toBe('playing');
+  });
+
+  it('should have default i18n from I18nService', async () => {
+    await elementIsStable(element);
+    expect(element.i18n).toBeDefined();
+    expect(typeof element.i18n.play).toBe('string');
+    expect(typeof element.i18n.pause).toBe('string');
+  });
+
+  it('should support custom i18n', async () => {
+    const customI18n = { play: 'Start', pause: 'Stop' };
+    element.i18n = customI18n;
+    await elementIsStable(element);
+    expect(element.i18n.play).toBe('Start');
+    expect(element.i18n.pause).toBe('Stop');
+  });
+
+  it('should support custom slot content', async () => {
+    element.innerHTML = '<bp-icon shape="play-circle" size="md"></bp-icon>';
+    await elementIsStable(element);
+
+    const slot = element.shadowRoot.querySelector('slot');
+    const assignedElements = slot.assignedElements();
+
+    expect(assignedElements.length).toBe(1);
+    expect(assignedElements[0].tagName.toLowerCase()).toBe('bp-icon');
+    expect(assignedElements[0].getAttribute('shape')).toBe('play-circle');
+  });
+
+  it('should be form associated', async () => {
+    await elementIsStable(element);
+    expect(element._internals.form).toBeNull(); // No form in test fixture
+    expect(BpButtonPlay.formAssociated).toBe(true);
+  });
+
+  it('should have name property', async () => {
+    await elementIsStable(element);
+    expect(element.name).toBe('playback');
+  });
+
+  it('should support CSS states for disabled', async () => {
+    await elementIsStable(element);
+    expect(element.matches(':state(disabled)')).toBe(false);
+
+    element.disabled = true;
+    await elementIsStable(element);
+    expect(element.matches(':state(disabled)')).toBe(true);
+  });
+
+  it('should support CSS states for readonly', async () => {
+    await elementIsStable(element);
+    expect(element.matches(':state(readonly)')).toBe(false);
+
+    element.readonly = true;
+    await elementIsStable(element);
+    expect(element.matches(':state(readonly)')).toBe(true);
+  });
+
+  it('should toggle checked state on click', async () => {
+    await elementIsStable(element);
+    expect(element.checked).toBeFalsy();
+
+    element.click();
+    await elementIsStable(element);
+    expect(element.checked).toBe(true);
+
+    element.click();
+    await elementIsStable(element);
+    expect(element.checked).toBe(false);
+  });
+
+  it('should not change state when disabled', async () => {
+    element.disabled = true;
+    await elementIsStable(element);
+    expect(element.checked).toBeFalsy();
+
+    element.click();
+    await elementIsStable(element);
+    expect(element.checked).toBeFalsy();
+  });
+
+  it('should not change state when readonly', async () => {
+    element.readonly = true;
+    await elementIsStable(element);
+    expect(element.checked).toBeFalsy();
+
+    element.click();
+    await elementIsStable(element);
+    expect(element.checked).toBeFalsy();
+  });
+
+  it('should have correct icon part', async () => {
+    await elementIsStable(element);
+    const icon = element.shadowRoot.querySelector('[part="icon"]');
+    expect(icon).toBeTruthy();
+    expect(icon.tagName.toLowerCase()).toBe('bp-icon');
+  });
+
+  it('should have correct button part', async () => {
+    await elementIsStable(element);
+    const button = element.shadowRoot.querySelector('[part="button"]');
+    expect(button).toBeTruthy();
+  });
+
+  it('should support custom value', async () => {
+    element.value = 'custom-value';
+    await elementIsStable(element);
+    expect(element.value).toBe('custom-value');
+    expect(element.getAttribute('value')).toBe('custom-value');
+  });
+
+  it('should not override custom aria-label', async () => {
+    const customElement = await createFixture(html`<bp-button-play aria-label="custom label"></bp-button-play>`);
+    const el = customElement.querySelector<BpButtonPlay>('bp-button-play');
+    await elementIsStable(el);
+
+    // Custom aria-label should be preserved
+    expect(el.getAttribute('aria-label')).toBe('custom label');
+
+    el.checked = true;
+    await elementIsStable(el);
+
+    // Custom aria-label should still be preserved after state change
+    expect(el.getAttribute('aria-label')).toBe('custom label');
+
+    removeFixture(customElement);
+  });
+});

--- a/projects/components/src/button-play/element.ts
+++ b/projects/components/src/button-play/element.ts
@@ -1,0 +1,99 @@
+import { html, LitElement, PropertyValues } from 'lit';
+import { property } from 'lit/decorators/property.js';
+import {
+  baseStyles,
+  i18n,
+  I18nService,
+  I18nStrings,
+  interactionClick,
+  interactionStyles,
+  stateActive
+} from '@blueprintui/components/internals';
+import { typeFormCheckbox, typeFormControl, TypeFormControl } from '@blueprintui/components/forms';
+import styles from './element.css' with { type: 'css' };
+
+export interface BpButtonPlay extends TypeFormControl {} // eslint-disable-line
+
+/**
+ * ```typescript
+ * import '@blueprintui/components/include/button-play.js';
+ * ```
+ *
+ * ```html
+ * <bp-button-play aria-label="play audio"></bp-button-play>
+ * ```
+ *
+ * @summary The button play component provides a toggle control for media playback states (play/pause).
+ * @element bp-button-play
+ * @since 2.11.0
+ * @slot - slot for custom play/pause icons
+ * @event {InputEvent} input - occurs when the value changes
+ * @event {InputEvent} change - occurs when the value changes
+ * @cssprop --background
+ * @cssprop --color
+ * @cssprop --border-color
+ * @cssprop --border-radius
+ * @cssprop --padding
+ * @cssprop --background-hover
+ * @cssprop --background-pressed
+ * @cssprop --color-pressed
+ * @cssprop --border-color-pressed
+ */
+@stateActive<BpButtonPlay>()
+@typeFormControl<BpButtonPlay>()
+@interactionClick<BpButtonPlay>()
+@i18n<BpButtonPlay>({ key: 'actions' })
+@typeFormCheckbox<BpButtonPlay>({ requireName: true })
+export class BpButtonPlay
+  extends LitElement
+  implements Pick<BpButtonPlay, 'value' | 'checked' | 'readonly' | 'disabled' | 'i18n'>
+{
+  /** determines initial value of the control */
+  @property({ type: String, reflect: true }) accessor value = 'on';
+
+  /** determines whether element is checked (playing) */
+  @property({ type: Boolean }) accessor checked: boolean;
+
+  @property({ type: Boolean }) accessor readonly: boolean;
+
+  /** determines if element is mutable or focusable */
+  @property({ type: Boolean }) accessor disabled: boolean;
+
+  /** represents the name of the current <form> element as a string. */
+  declare name: string;
+
+  @property({ type: Object }) accessor i18n: I18nStrings['actions'] = I18nService.keys.actions;
+
+  static formAssociated = true;
+
+  static styles = [baseStyles, interactionStyles, styles];
+
+  render() {
+    return html`
+      <div part="button" interaction-after>
+        <slot>
+          ${this.checked
+            ? html`<bp-icon part="icon" shape="pause" size="sm"></bp-icon>`
+            : html`<bp-icon part="icon" shape="play" size="sm"></bp-icon>`}
+        </slot>
+      </div>
+    `;
+  }
+
+  firstUpdated(props: PropertyValues<this>) {
+    super.firstUpdated(props);
+    this._internals.role = 'button';
+    this._internals.ariaLabel ??= this.checked ? this.i18n.pause : this.i18n.play;
+  }
+
+  updated(props: PropertyValues<this>) {
+    super.updated(props);
+    if (props.has('checked')) {
+      this._internals.ariaPressed = this.checked ? 'true' : 'false';
+      // Update aria-label based on checked state if no custom label is set
+      if (!this.hasAttribute('aria-label') && !this.hasAttribute('aria-labelledby')) {
+        this._internals.ariaLabel = this.checked ? this.i18n.pause : this.i18n.play;
+      }
+    }
+  }
+}

--- a/projects/components/src/button-play/element.visual.ts
+++ b/projects/components/src/button-play/element.visual.ts
@@ -1,0 +1,32 @@
+import { html } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { visualDiff } from '@web/test-runner-visual-regression';
+import { createVisualFixture, removeFixture } from '@blueprintui/test';
+import * as buttonPlay from './element.examples.js';
+import '@blueprintui/components/include/button-play.js';
+
+describe('bp-button-play', () => {
+  let fixture: HTMLElement;
+
+  beforeEach(async () => {
+    fixture = await createVisualFixture(
+      html`
+        ${unsafeHTML(buttonPlay.example())} ${unsafeHTML(buttonPlay.disabled())} ${unsafeHTML(buttonPlay.readonly())}
+      `,
+      { width: '800px', height: '300px' }
+    );
+  });
+
+  afterEach(() => {
+    removeFixture(fixture);
+  });
+
+  it('light theme', async () => {
+    await visualDiff(fixture, 'button-play/light.png');
+  });
+
+  it('dark theme', async () => {
+    document.documentElement.setAttribute('bp-theme', 'dark');
+    await visualDiff(fixture, 'button-play/dark.png');
+  });
+});

--- a/projects/components/src/button-play/index.ts
+++ b/projects/components/src/button-play/index.ts
@@ -1,0 +1,1 @@
+export { BpButtonPlay } from './element.js';

--- a/projects/components/src/include/all.ts
+++ b/projects/components/src/include/all.ts
@@ -6,6 +6,7 @@ import '@blueprintui/components/include/button-expand.js';
 import '@blueprintui/components/include/button-group.js';
 import '@blueprintui/components/include/button-handle.js';
 import '@blueprintui/components/include/button-icon.js';
+import '@blueprintui/components/include/button-play.js';
 import '@blueprintui/components/include/button-sort.js';
 import '@blueprintui/components/include/button.js';
 import '@blueprintui/components/include/card.js';

--- a/projects/components/src/include/button-play.ts
+++ b/projects/components/src/include/button-play.ts
@@ -1,0 +1,13 @@
+import '@blueprintui/icons/include.js';
+import '@blueprintui/icons/shapes/play.js';
+import '@blueprintui/icons/shapes/pause.js';
+import { defineElement } from '@blueprintui/components/internals';
+import { BpButtonPlay } from '@blueprintui/components/button-play';
+
+defineElement('bp-button-play', BpButtonPlay);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'bp-button-play': BpButtonPlay;
+  }
+}

--- a/projects/components/src/include/lazy.ts
+++ b/projects/components/src/include/lazy.ts
@@ -7,6 +7,7 @@ export const loader = {
   'button-group': () => import('@blueprintui/components/include/button-group.js'),
   'button-handle': () => import('@blueprintui/components/include/button-handle.js'),
   'button-icon': () => import('@blueprintui/components/include/button-icon.js'),
+  'button-play': () => import('@blueprintui/components/include/button-play.js'),
   'button-sort': () => import('@blueprintui/components/include/button-sort.js'),
   button: () => import('@blueprintui/components/include/button.js'),
   card: () => import('@blueprintui/components/include/card.js'),

--- a/projects/components/src/internals/services/i18n.service.ts
+++ b/projects/components/src/internals/services/i18n.service.ts
@@ -32,6 +32,8 @@ export interface I18nStrings {
     nextPage: string;
     lastPage: string;
     pageSize: string;
+    play: string;
+    pause: string;
   };
 }
 
@@ -65,7 +67,9 @@ export const i18nRegistry: I18nStrings = {
     previousPage: 'go to previous page',
     nextPage: 'go to next page',
     lastPage: 'go to last page',
-    pageSize: 'items per page'
+    pageSize: 'items per page',
+    play: 'play',
+    pause: 'pause'
   }
 };
 


### PR DESCRIPTION
Add a new toggle button component for media playback control (play/pause).

Component Features:
- Toggle control for play/pause states using checked boolean property
- Form participation with name attribute for form submission
- Full accessibility support with role="button" and aria-pressed
- Supports disabled and readonly states
- Auto-updates aria-label based on state (play/pause)
- Custom value support for form submission
- Uses design tokens for styling with CSS custom properties
- Includes play and pause icon shapes

Files Added:
- button-play/element.ts - Component implementation
- button-play/element.css - Component styles
- button-play/element.spec.ts - Comprehensive unit tests
- button-play/element.visual.ts - Visual regression tests
- button-play/element.performance.ts - Performance benchmarks
- button-play/element.examples.js - Documentation examples
- button-play/index.ts - Public exports
- include/button-play.ts - Component registration

Updates:
- Added play and pause to I18nStrings for internationalization
- Registered component in include/all.ts and include/lazy.ts
- Uses play and pause icon shapes from @blueprintui/icons

API:
- Properties: checked, disabled, readonly, name, value
- Events: change, input
- CSS Parts: button, icon
- CSS Properties: --background, --color, --border-color, --border-radius, --padding, --background-hover, --background-pressed, --color-pressed, --border-color-pressed