### PR TITLE
Add icon components documentation page

### DIFF
--- a/projects/docs/src/_layouts/base.11ty.js
+++ b/projects/docs/src/_layouts/base.11ty.js
@@ -101,6 +101,7 @@ export function render(data) {
               <bp-tree-item ${data.page.url === '/docs/components/form-interactions.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/form-interactions.html">Form Interactions</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/form-validation.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/form-validation.html">Form Validation</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/header.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/header.html">Header</a></bp-tree-item>
+              <bp-tree-item ${data.page.url === '/docs/components/icon.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/icon.html">Icon</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/input.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/input.html">Input</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/menu.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/menu.html">Menu</a></bp-tree-item>
               <bp-tree-item ${data.page.url === '/docs/components/month.html' ? 'selected aria-current="page"' : ''}><a href="/docs/components/month.html">Month</a></bp-tree-item>

--- a/projects/docs/src/_pages/components/icon.11ty.js
+++ b/projects/docs/src/_pages/components/icon.11ty.js
@@ -1,5 +1,5 @@
 import schema from '../../../../icons/.drafter/schema.json' with { type: 'json' };
-import { getExample, getAPI, getElementSummary } from '../../_includes/utils/index.js';
+import { getExample, getAPI } from '../../_includes/utils/index.js';
 
 export const data = {
   title: 'Icon',
@@ -8,7 +8,7 @@ export const data = {
 
 export function render() {
   return /* markdown */`
-${getElementSummary(data.schema, 'bp-icon')}
+<p bp-text="subsection">The icon component provides a flexible way to render SVG-based icons with support for different sizes, types, and visual states.</p>
 
 ${getExample(data.schema, 'example')}
 

--- a/projects/docs/src/_pages/components/icon.11ty.js
+++ b/projects/docs/src/_pages/components/icon.11ty.js
@@ -1,0 +1,48 @@
+import schema from '../../../../icons/.drafter/schema.json' with { type: 'json' };
+import { getExample, getAPI, getElementSummary } from '../../_includes/utils/index.js';
+
+export const data = {
+  title: 'Icon',
+  schema: schema.find(c => c.name === 'icon')
+};
+
+export function render() {
+  return /* markdown */`
+${getElementSummary(data.schema, 'bp-icon')}
+
+${getExample(data.schema, 'example')}
+
+${getExample(data.schema, 'size')}
+
+${getExample(data.schema, 'solid')}
+
+${getExample(data.schema, 'badge')}
+
+## Install
+
+### NPM
+
+\`\`\`typescript
+// npm package
+import '@blueprintui/icons/include.js';
+import '@blueprintui/icons/shapes/user.js';
+\`\`\`
+
+### CDN
+
+\`\`\`html
+<script type="module">
+  import 'https://cdn.jsdelivr.net/npm/@blueprintui/icons/include.js/+esm';
+  import 'https://cdn.jsdelivr.net/npm/@blueprintui/icons/shapes/user.js/+esm';
+</script>
+\`\`\`
+
+## Accessibility
+- Use a descriptive aria-label attribute to provide text alternative for the icon.
+- Decorative icons that do not convey meaning should use \`aria-hidden="true"\`.
+- Icons used as interactive elements should have sufficient color contrast.
+- Avoid using icons as the only means of conveying information.
+
+${getAPI(data.schema)}
+`;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces documentation for the `Icon` component and wires it into the site navigation.
> 
> - Adds `projects/docs/src/_pages/components/icon.11ty.js` rendering examples (`example`, `size`, `solid`, `badge`), install instructions (NPM/CDN), accessibility guidance, and API via `schema` + `getAPI`
> - Updates `projects/docs/src/_layouts/base.11ty.js` to include a new `Icon` entry in the Components sidebar with selected-state handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34ff93ead89464130447c50b9f15b663fd28f983. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->