### PR TITLE
chore(build): update jasmine 6.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 0.10.0
       version: 0.10.0
     '@types/jasmine':
-      specifier: 5.1.9
-      version: 5.1.9
+      specifier: 6.0.0
+      version: 6.0.0
     '@web/dev-server':
       specifier: 0.4.6
       version: 0.4.6
@@ -46,11 +46,11 @@ catalogs:
       specifier: 6.0.0
       version: 6.0.0
     jasmine:
-      specifier: 5.10.0
-      version: 5.10.0
+      specifier: 6.0.0
+      version: 6.0.0
     jasmine-core:
-      specifier: 5.10.0
-      version: 5.10.0
+      specifier: 6.0.0
+      version: 6.0.0
     lit:
       specifier: ^3.3.1
       version: 3.3.1
@@ -73,8 +73,8 @@ catalogs:
       specifier: 7.1.5
       version: 7.1.5
     web-test-runner-jasmine:
-      specifier: 0.1.4
-      version: 0.1.4
+      specifier: 0.2.0
+      version: 0.2.0
     web-test-runner-performance:
       specifier: 0.1.6
       version: 0.1.6
@@ -236,7 +236,7 @@ importers:
         version: link:../internals/test
       '@types/jasmine':
         specifier: 'catalog:'
-        version: 5.1.9
+        version: 6.0.0
       '@web/dev-server':
         specifier: 'catalog:'
         version: 0.4.6
@@ -266,10 +266,10 @@ importers:
         version: 6.0.0
       jasmine:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       jasmine-core:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       playwright:
         specifier: 'catalog:'
         version: 1.58.0
@@ -278,7 +278,7 @@ importers:
         version: 0.3.12
       web-test-runner-jasmine:
         specifier: 'catalog:'
-        version: 0.1.4(jasmine-core@5.10.0)(jasmine@5.10.0)
+        version: 0.2.0(jasmine-core@6.0.0)
       web-test-runner-performance:
         specifier: 'catalog:'
         version: 0.1.6(rollup@4.50.1)
@@ -319,7 +319,7 @@ importers:
         version: link:../internals/test
       '@types/jasmine':
         specifier: 'catalog:'
-        version: 5.1.9
+        version: 6.0.0
       '@web/dev-server':
         specifier: 'catalog:'
         version: 0.4.6
@@ -340,10 +340,10 @@ importers:
         version: 0.11.1
       jasmine:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       jasmine-core:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       playwright:
         specifier: 'catalog:'
         version: 1.58.0
@@ -352,7 +352,7 @@ importers:
         version: 0.3.12
       web-test-runner-jasmine:
         specifier: 'catalog:'
-        version: 0.1.4(jasmine-core@5.10.0)(jasmine@5.10.0)
+        version: 0.2.0(jasmine-core@6.0.0)
       web-test-runner-performance:
         specifier: 'catalog:'
         version: 0.1.6(rollup@4.50.1)
@@ -648,7 +648,7 @@ importers:
         version: link:../virtual
       '@types/jasmine':
         specifier: 'catalog:'
-        version: 5.1.9
+        version: 6.0.0
       '@web/dev-server':
         specifier: 'catalog:'
         version: 0.4.6
@@ -675,10 +675,10 @@ importers:
         version: 6.0.0
       jasmine:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       jasmine-core:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       modern-normalize:
         specifier: 'catalog:'
         version: 3.0.1
@@ -690,7 +690,7 @@ importers:
         version: 0.3.12
       web-test-runner-jasmine:
         specifier: 'catalog:'
-        version: 0.1.4(jasmine-core@5.10.0)(jasmine@5.10.0)
+        version: 0.2.0(jasmine-core@6.0.0)
       web-test-runner-performance:
         specifier: 'catalog:'
         version: 0.1.6(rollup@4.50.1)
@@ -724,7 +724,7 @@ importers:
         version: link:../typography
       '@types/jasmine':
         specifier: 'catalog:'
-        version: 5.1.9
+        version: 6.0.0
       '@web/dev-server':
         specifier: 'catalog:'
         version: 0.4.6
@@ -748,10 +748,10 @@ importers:
         version: 0.10.0
       jasmine:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       jasmine-core:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       playwright:
         specifier: 'catalog:'
         version: 1.58.0
@@ -763,7 +763,7 @@ importers:
         version: 5.9.2
       web-test-runner-jasmine:
         specifier: 'catalog:'
-        version: 0.1.4(jasmine-core@5.10.0)(jasmine@5.10.0)
+        version: 0.2.0(jasmine-core@6.0.0)
       web-test-runner-performance:
         specifier: 'catalog:'
         version: 0.1.6(rollup@4.50.1)
@@ -819,13 +819,13 @@ importers:
     devDependencies:
       '@types/jasmine':
         specifier: 'catalog:'
-        version: 5.1.9
+        version: 6.0.0
       jasmine:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       jasmine-core:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.2
@@ -846,7 +846,7 @@ importers:
         version: link:../internals/test
       '@types/jasmine':
         specifier: 'catalog:'
-        version: 5.1.9
+        version: 6.0.0
       '@web/dev-server':
         specifier: 'catalog:'
         version: 0.4.6
@@ -873,10 +873,10 @@ importers:
         version: 4.25.4
       jasmine:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       jasmine-core:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       lit:
         specifier: 'catalog:'
         version: 3.3.1
@@ -885,7 +885,7 @@ importers:
         version: 0.3.12
       web-test-runner-jasmine:
         specifier: 'catalog:'
-        version: 0.1.4(jasmine-core@5.10.0)(jasmine@5.10.0)
+        version: 0.2.0(jasmine-core@6.0.0)
       web-test-runner-performance:
         specifier: 'catalog:'
         version: 0.1.6(rollup@4.50.1)
@@ -917,7 +917,7 @@ importers:
         version: link:../internals/test
       '@types/jasmine':
         specifier: 'catalog:'
-        version: 5.1.9
+        version: 6.0.0
       '@web/dev-server':
         specifier: 'catalog:'
         version: 0.4.6
@@ -938,10 +938,10 @@ importers:
         version: 0.11.1
       jasmine:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       jasmine-core:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       lit:
         specifier: 'catalog:'
         version: 3.3.1
@@ -950,7 +950,7 @@ importers:
         version: 0.3.12
       web-test-runner-jasmine:
         specifier: 'catalog:'
-        version: 0.1.4(jasmine-core@5.10.0)(jasmine@5.10.0)
+        version: 0.2.0(jasmine-core@6.0.0)
 
   projects/themes:
     devDependencies:
@@ -959,7 +959,7 @@ importers:
         version: link:../internals/test
       '@types/jasmine':
         specifier: 'catalog:'
-        version: 5.1.9
+        version: 6.0.0
       '@web/dev-server':
         specifier: 'catalog:'
         version: 0.4.6
@@ -983,10 +983,10 @@ importers:
         version: 5.0.5
       jasmine:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       jasmine-core:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       playwright:
         specifier: 'catalog:'
         version: 1.58.0
@@ -995,7 +995,7 @@ importers:
         version: 0.3.12
       web-test-runner-jasmine:
         specifier: 'catalog:'
-        version: 0.1.4(jasmine-core@5.10.0)(jasmine@5.10.0)
+        version: 0.2.0(jasmine-core@6.0.0)
       web-test-runner-performance:
         specifier: 'catalog:'
         version: 0.1.6(rollup@4.50.1)
@@ -1026,7 +1026,7 @@ importers:
         version: link:../themes
       '@types/jasmine':
         specifier: 'catalog:'
-        version: 5.1.9
+        version: 6.0.0
       '@web/dev-server':
         specifier: 'catalog:'
         version: 0.4.6
@@ -1047,16 +1047,16 @@ importers:
         version: 0.11.1
       jasmine:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       jasmine-core:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       publint:
         specifier: 'catalog:'
         version: 0.3.12
       web-test-runner-jasmine:
         specifier: 'catalog:'
-        version: 0.1.4(jasmine-core@5.10.0)(jasmine@5.10.0)
+        version: 0.2.0(jasmine-core@6.0.0)
       web-test-runner-performance:
         specifier: 'catalog:'
         version: 0.1.6(rollup@4.50.1)
@@ -1077,7 +1077,7 @@ importers:
         version: link:../internals/test
       '@types/jasmine':
         specifier: 'catalog:'
-        version: 5.1.9
+        version: 6.0.0
       '@web/dev-server':
         specifier: 'catalog:'
         version: 0.4.6
@@ -1104,10 +1104,10 @@ importers:
         version: 4.25.4
       jasmine:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       jasmine-core:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       lit:
         specifier: 'catalog:'
         version: 3.3.1
@@ -1119,7 +1119,7 @@ importers:
         version: 0.3.12
       web-test-runner-jasmine:
         specifier: 'catalog:'
-        version: 0.1.4(jasmine-core@5.10.0)(jasmine@5.10.0)
+        version: 0.2.0(jasmine-core@6.0.0)
       web-test-runner-performance:
         specifier: 'catalog:'
         version: 0.1.6(rollup@4.50.1)
@@ -1150,7 +1150,7 @@ importers:
         version: link:../themes
       '@types/jasmine':
         specifier: 'catalog:'
-        version: 5.1.9
+        version: 6.0.0
       '@web/dev-server':
         specifier: 'catalog:'
         version: 0.4.6
@@ -1171,10 +1171,10 @@ importers:
         version: 0.11.1
       jasmine:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       jasmine-core:
         specifier: 'catalog:'
-        version: 5.10.0
+        version: 6.0.0
       lit:
         specifier: 'catalog:'
         version: 3.3.1
@@ -1189,7 +1189,7 @@ importers:
         version: 2.8.1
       web-test-runner-jasmine:
         specifier: 'catalog:'
-        version: 0.1.4(jasmine-core@5.10.0)(jasmine@5.10.0)
+        version: 0.2.0(jasmine-core@6.0.0)
       web-test-runner-performance:
         specifier: 'catalog:'
         version: 0.1.6(rollup@4.50.1)
@@ -2980,6 +2980,9 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
+  '@jasminejs/reporters@1.0.0':
+    resolution: {integrity: sha512-rM3GG4vx2H1Gp5kYCTr9aKlOEJFd43pzpiMAiy5b1+FUc2ub4e6bS6yCi/WQNDzAa5MVp9++dwcoEtcIfoEnhA==}
+
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4299,8 +4302,8 @@ packages:
   '@types/jasmine@5.1.5':
     resolution: {integrity: sha512-SaCZ3kM5NjOiJqMRYwHpLbTfUC2Dyk1KS3QanNFsUYPGTk70CWVK/J9ueun6zNhw/UkgV7xl8V4ZLQZNRbfnNw==}
 
-  '@types/jasmine@5.1.9':
-    resolution: {integrity: sha512-8t4HtkW4wxiPVedMpeZ63n3vlWxEIquo/zc1Tm8ElU+SqVV7+D3Na2PWaJUp179AzTragMWVwkMv7mvty0NfyQ==}
+  '@types/jasmine@6.0.0':
+    resolution: {integrity: sha512-18lgGsLmEh3VJk9eZ5wAjTISxdqzl6YOwu8UdMpolajN57QOCNbl+AbHUd+Yu9ItrsFdB+c8LSZSGNg8nHaguw==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -7534,14 +7537,14 @@ packages:
   jasmine-core@4.6.1:
     resolution: {integrity: sha512-VYz/BjjmC3klLJlLwA4Kw8ytk0zDSmbbDLNs794VnWmkcCB7I9aAL/D48VNQtmITyPvea2C3jdUMfc3kAoy0PQ==}
 
-  jasmine-core@5.10.0:
-    resolution: {integrity: sha512-MrChbWV5LBo+EaeKwTM1eZ6oYSz1brvFExnRafraEkJkbJ9evbUxABhnIgGQimhpMxhg+BD6QmOvb/e3NXsNdg==}
-
   jasmine-core@5.5.0:
     resolution: {integrity: sha512-NHOvoPO6o9gVR6pwqEACTEpbgcH+JJ6QDypyymGbSUIFIFsMMbBJ/xsFNud8MSClfnWclXd7RQlAZBz7yVo5TQ==}
 
-  jasmine@5.10.0:
-    resolution: {integrity: sha512-v4FojO8cXQdx15mJXovGhjJOvyIcVf7AC+H0ZahnfLk52vUbwuLxjVgbikc95yLmgwKQsFT47/FGQ3dOrWVxtQ==}
+  jasmine-core@6.0.0:
+    resolution: {integrity: sha512-fmBb8aruz2mEIDBUGWOGNmxhXwFJs44SSzwbMcBDqQnNChavPTq3Ra9A6WAn6WdxvxWEdakKTcEb3NzeR3yD1A==}
+
+  jasmine@6.0.0:
+    resolution: {integrity: sha512-eSPL6LPWT39WwvHSEEbRXuSvioXMTheNhIPaeUT1OPmSprDZwj4S29884DkTx6/tyiOWTWB1N+LdW2ZSg74aEA==}
     hasBin: true
 
   java-properties@1.0.2:
@@ -11094,12 +11097,11 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  web-test-runner-jasmine@0.1.4:
-    resolution: {integrity: sha512-SVR+SiacD7UuHrr5PwvZ+mDmDT940vuURK44XJS5WEqBdjZMdrmkgJQOyQgPbK2IKQi/eODKCBJ6rTkTKLIeCA==}
-    engines: {node: ^22.15.1}
+  web-test-runner-jasmine@0.2.0:
+    resolution: {integrity: sha512-OgREqleExLUBNj9POdzJ35V/S9OMhNNKjTOvasfx6fvtGKXbyfLa5qyCH2ltHFel6vCl5crjC8uQMr+KecnUgA==}
+    engines: {node: '>=24.0.0'}
     peerDependencies:
-      jasmine: ^5.8.0
-      jasmine-core: ^5.8.0
+      jasmine-core: ^6.0.1
 
   web-test-runner-performance@0.1.6:
     resolution: {integrity: sha512-ND9UTAQ+4oWIjnZFlxtsm/5keTx4nbZiZ+7OSkARqd/a8Uk8v2Kocgy3oDjAWrRpl2jixnNYESyCcW+bKyquSg==}
@@ -13455,6 +13457,8 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
+  '@jasminejs/reporters@1.0.0': {}
+
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.8
@@ -14746,7 +14750,7 @@ snapshots:
 
   '@types/jasmine@5.1.5': {}
 
-  '@types/jasmine@5.1.9': {}
+  '@types/jasmine@6.0.0': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -18745,14 +18749,15 @@ snapshots:
 
   jasmine-core@4.6.1: {}
 
-  jasmine-core@5.10.0: {}
-
   jasmine-core@5.5.0: {}
 
-  jasmine@5.10.0:
+  jasmine-core@6.0.0: {}
+
+  jasmine@6.0.0:
     dependencies:
-      glob: 10.4.5
-      jasmine-core: 5.10.0
+      '@jasminejs/reporters': 1.0.0
+      glob: 11.0.3
+      jasmine-core: 6.0.0
 
   java-properties@1.0.2: {}
 
@@ -22559,13 +22564,11 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  web-test-runner-jasmine@0.1.4(jasmine-core@5.10.0)(jasmine@5.10.0):
+  web-test-runner-jasmine@0.2.0(jasmine-core@6.0.0):
     dependencies:
       '@web/test-runner': 0.20.2
       '@web/test-runner-core': 0.13.4
-      ansi-colors: 4.1.3
-      jasmine: 5.10.0
-      jasmine-core: 5.10.0
+      jasmine-core: 6.0.0
     transitivePeerDependencies:
       - bare-buffer
       - bufferutil

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ packages:
 catalog:
   '@blueprintui/cli': 0.11.3
   '@blueprintui/drafter': 0.10.0
-  '@types/jasmine': 5.1.9
+  '@types/jasmine': 6.0.0
   '@web/dev-server': 0.4.6
   '@web/dev-server-esbuild': 1.0.4
   '@web/dev-server-rollup': 0.6.4
@@ -30,8 +30,8 @@ catalog:
   browserslist: 4.25.4
   custom-element-types: 0.0.2
   del-cli: 6.0.0
-  jasmine: 5.10.0
-  jasmine-core: 5.10.0
+  jasmine: 6.0.0
+  jasmine-core: 6.0.0
   lit: ^3.3.1
   modern-normalize: ^3.0.1
   playwright: 1.58.0
@@ -39,7 +39,7 @@ catalog:
   tslib: ^2.8.1
   typescript: 5.9.2
   vite: 7.1.5
-  web-test-runner-jasmine: 0.1.4
+  web-test-runner-jasmine: 0.2.0
   web-test-runner-performance: 0.1.6
 
 ignoredBuiltDependencies:
@@ -53,6 +53,7 @@ minimumReleaseAgeExclude:
   - playwright
   - playwright-core
   - '@blueprintui/drafter'
+  - web-test-runner-jasmine
 managePackageManagerVersions: true
 packageManagerStrictVersions: true
 verifyDepsBeforeRun: install

--- a/projects/components/src/internals/utils/a11y.spec.ts
+++ b/projects/components/src/internals/utils/a11y.spec.ts
@@ -57,7 +57,7 @@ describe('associateInputAndLabel', () => {
     removeFixture(label);
   });
 
-  it('should associate the label and input using a id and for attribute', async () => {
+  it('should focus input when label is clicked', async () => {
     const input = (await createFixture()) as HTMLInputElement;
     const label = (await createFixture()) as HTMLLabelElement;
     associateInputAndLabel(input, label);

--- a/projects/components/src/tabs/element.spec.ts
+++ b/projects/components/src/tabs/element.spec.ts
@@ -62,7 +62,7 @@ describe('bp-tabs', () => {
     expect((tabList as any)._internals.role).toBe('tablist');
   });
 
-  it('should assign tablist to appropriate slot', async () => {
+  it('should have tablist slot', async () => {
     await elementIsStable(element);
     expect(tabList.slot).toBe('tablist');
   });
@@ -74,7 +74,7 @@ describe('bp-tabs', () => {
     expect((panels[2] as any)._internals.role).toBe('tabpanel');
   });
 
-  it('should assign tablist to appropriate slot', async () => {
+  it('should assign tabpanel slots', async () => {
     await elementIsStable(element);
     expect(panels[0].slot).toBe('tabpanel');
     expect(panels[1].slot).toBe('tabpanel');

--- a/projects/grid/src/row/element.visual.ts
+++ b/projects/grid/src/row/element.visual.ts
@@ -115,16 +115,6 @@ describe('row', () => {
     await visualDiff(fixture, 'row-sort/dark.png');
   });
 
-  it('sort light theme', async () => {
-    fixture = await createGridVisualFixture(examples.sort());
-    await visualDiff(fixture, 'row-sort/light.png');
-  });
-
-  it('sort dark theme', async () => {
-    fixture = await createGridVisualFixture(examples.sort(), { theme: 'dark' });
-    await visualDiff(fixture, 'row-sort/dark.png');
-  });
-
   it('row-groups light theme', async () => {
     fixture = await createGridVisualFixture(examples.groups());
     await visualDiff(fixture, 'row-groups/light.png');


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrades the testing stack to Jasmine 6 across the monorepo and aligns tooling.
> 
> - Bumps `jasmine`/`jasmine-core` and `@types/jasmine` to `6.0.0`; updates `web-test-runner-jasmine` to `0.2.0` in `pnpm-workspace.yaml` and lockfile
> - Adjusts workspace catalog and `minimumReleaseAgeExclude`; adds `@jasminejs/reporters` via lockfile; `web-test-runner-jasmine` now requires Node >=24
> - Minor test tweaks: rename a few spec titles in `a11y.spec.ts` and `tabs/element.spec.ts`; remove duplicated visual tests in `grid/src/row/element.visual.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a3cb9bf6fd85df93a0399b9ad99445a7d32df6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->