### PR TITLE
feat(components): add scoped custom element registry support

### DIFF
--- a/projects/components/blueprint.config.js
+++ b/projects/components/blueprint.config.js
@@ -1,7 +1,7 @@
 export default {
   library: {
     minify: false,
-    entryPoints: ['./src/**/index.ts', './src/include/*.ts'],
+    entryPoints: ['./src/**/index.ts', './src/include/*.ts', './src/scoped-registry.ts'],
     externals: [/^tslib/, /^lit/, /^@blueprintui/]
   },
   drafter: {

--- a/projects/components/custom-elements.lock.json
+++ b/projects/components/custom-elements.lock.json
@@ -13904,6 +13904,27 @@
         },
         {
           "kind": "function",
+          "name": "setRegistry",
+          "parameters": [
+            {
+              "name": "registry",
+              "type": {
+                "text": "CustomElementRegistry | undefined"
+              }
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "getRegistry",
+          "return": {
+            "type": {
+              "text": "CustomElementRegistry"
+            }
+          }
+        },
+        {
+          "kind": "function",
           "name": "defineElement",
           "parameters": [
             {
@@ -13932,17 +13953,25 @@
         },
         {
           "kind": "js",
-          "name": "defineElement",
+          "name": "setRegistry",
           "declaration": {
-            "name": "defineElement",
+            "name": "setRegistry",
             "module": "internals/utils/define.js"
           }
         },
         {
-          "kind": "custom-element-definition",
-          "name": "name",
+          "kind": "js",
+          "name": "getRegistry",
           "declaration": {
-            "name": "element",
+            "name": "getRegistry",
+            "module": "internals/utils/define.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "defineElement",
+          "declaration": {
+            "name": "defineElement",
             "module": "internals/utils/define.js"
           }
         }
@@ -19780,6 +19809,56 @@
           "declaration": {
             "name": "*",
             "module": "rating/element.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "scoped-registry.js",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "createBlueprintRegistry",
+          "return": {
+            "type": {
+              "text": "Promise<CustomElementRegistry>"
+            }
+          },
+          "parameters": [
+            {
+              "name": "loaders",
+              "type": {
+                "text": "(() => Promise<unknown>)[]"
+              }
+            }
+          ],
+          "description": "Creates a new scoped `CustomElementRegistry` and registers Blueprint UI\ncomponents into it by executing the provided loader functions.\n\nThe returned registry can be passed to `attachShadow({ customElementRegistry })`\nso that Blueprint UI elements are resolved within that shadow root without\npolluting the global `customElements` registry.\n\nFalls back to the global registry when `CustomElementRegistry` is not\nconstructible (Firefox < 135 and older browsers)."
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "setRegistry",
+          "declaration": {
+            "name": "setRegistry",
+            "module": "./internals/utils/define.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "getRegistry",
+          "declaration": {
+            "name": "getRegistry",
+            "module": "./internals/utils/define.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "createBlueprintRegistry",
+          "declaration": {
+            "name": "createBlueprintRegistry",
+            "module": "scoped-registry.js"
           }
         }
       ]

--- a/projects/components/package.json
+++ b/projects/components/package.json
@@ -38,6 +38,10 @@
   "exports": {
     "./package.json": "./package.json",
     "./custom-elements.json": "./dist/custom-elements.json",
+    "./scoped-registry": {
+      "types": "./dist/scoped-registry.d.ts",
+      "default": "./dist/scoped-registry.js"
+    },
     "./include/*.js": {
       "types": "./dist/include/*.d.ts",
       "default": "./dist/include/*.js"

--- a/projects/components/src/global.d.ts
+++ b/projects/components/src/global.d.ts
@@ -62,3 +62,12 @@ interface HTMLElementEventMap {
   beforetoggle: ToggleEvent;
   toggle: ToggleEvent;
 }
+
+interface CustomElementRegistryConstructor {
+  new (): CustomElementRegistry;
+  prototype: CustomElementRegistry;
+}
+
+interface ShadowRootInit {
+  customElementRegistry?: CustomElementRegistry;
+}

--- a/projects/components/src/internals/utils/define.spec.ts
+++ b/projects/components/src/internals/utils/define.spec.ts
@@ -1,0 +1,129 @@
+import { LitElement, html } from 'lit';
+import { defineElement, setRegistry, getRegistry } from '@blueprintui/components/internals';
+
+describe('defineElement', () => {
+  afterEach(() => {
+    setRegistry(undefined);
+  });
+
+  it('should define an element on the global registry by default', () => {
+    class TestDefineGlobal extends HTMLElement {}
+    defineElement('test-define-global', TestDefineGlobal);
+    expect(customElements.get('test-define-global')).toBe(TestDefineGlobal);
+  });
+
+  it('should not redefine an already-defined element', () => {
+    class TestDefineOnce extends HTMLElement {}
+    defineElement('test-define-once', TestDefineOnce);
+    expect(() => defineElement('test-define-once', TestDefineOnce)).not.toThrow();
+  });
+
+  it('should set __meta on the element class', () => {
+    class TestDefineMeta extends HTMLElement {
+      static __meta: any;
+    }
+    defineElement('test-define-meta', TestDefineMeta);
+    expect(TestDefineMeta.__meta).toEqual({ name: 'test-define-meta', version: '0.0.0' });
+  });
+});
+
+describe('setRegistry / getRegistry', () => {
+  afterEach(() => {
+    setRegistry(undefined);
+  });
+
+  it('should return the global customElements by default', () => {
+    expect(getRegistry()).toBe(customElements);
+  });
+
+  it('should return a custom registry after setRegistry', () => {
+    if (!supportsConstructableRegistry()) {
+      pending('CustomElementRegistry constructor not available');
+      return;
+    }
+    const registry = new CustomElementRegistry();
+    setRegistry(registry);
+    expect(getRegistry()).toBe(registry);
+  });
+
+  it('should fall back to global when reset to undefined', () => {
+    if (!supportsConstructableRegistry()) {
+      pending('CustomElementRegistry constructor not available');
+      return;
+    }
+    const registry = new CustomElementRegistry();
+    setRegistry(registry);
+    setRegistry(undefined);
+    expect(getRegistry()).toBe(customElements);
+  });
+});
+
+describe('defineElement with scoped registry', () => {
+  afterEach(() => {
+    setRegistry(undefined);
+  });
+
+  it('should define an element on the active scoped registry', () => {
+    if (!supportsConstructableRegistry()) {
+      pending('CustomElementRegistry constructor not available');
+      return;
+    }
+    const registry = new CustomElementRegistry();
+    setRegistry(registry);
+
+    class TestScopedEl extends HTMLElement {}
+    defineElement('test-scoped-el', TestScopedEl);
+
+    expect(registry.get('test-scoped-el')).toBe(TestScopedEl);
+    expect(customElements.get('test-scoped-el')).toBeUndefined();
+  });
+
+  it('should set shadowRootOptions.customElementRegistry for LitElement classes', () => {
+    if (!supportsConstructableRegistry()) {
+      pending('CustomElementRegistry constructor not available');
+      return;
+    }
+    const registry = new CustomElementRegistry();
+    setRegistry(registry);
+
+    class TestScopedLit extends LitElement {
+      static shadowRootOptions = { ...LitElement.shadowRootOptions };
+      render() {
+        return html`<slot></slot>`;
+      }
+    }
+
+    defineElement('test-scoped-lit', TestScopedLit);
+    expect((TestScopedLit as any).shadowRootOptions.customElementRegistry).toBe(registry);
+  });
+
+  it('should allow the same tag name in two different scoped registries', () => {
+    if (!supportsConstructableRegistry()) {
+      pending('CustomElementRegistry constructor not available');
+      return;
+    }
+    const registry1 = new CustomElementRegistry();
+    const registry2 = new CustomElementRegistry();
+
+    class TestDup1 extends HTMLElement {}
+    class TestDup2 extends HTMLElement {}
+
+    setRegistry(registry1);
+    defineElement('test-dup-tag', TestDup1);
+
+    setRegistry(registry2);
+    defineElement('test-dup-tag', TestDup2);
+
+    expect(registry1.get('test-dup-tag')).toBe(TestDup1);
+    expect(registry2.get('test-dup-tag')).toBe(TestDup2);
+  });
+});
+
+function supportsConstructableRegistry(): boolean {
+  try {
+    new CustomElementRegistry();
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/projects/components/src/internals/utils/define.ts
+++ b/projects/components/src/internals/utils/define.ts
@@ -7,9 +7,27 @@ export interface ElementMetadata {
   version: string;
 }
 
+let activeRegistry: CustomElementRegistry | undefined;
+
+export function setRegistry(registry: CustomElementRegistry | undefined) {
+  activeRegistry = registry;
+}
+
+export function getRegistry(): CustomElementRegistry {
+  return activeRegistry ?? customElements;
+}
+
 export function defineElement(name: string, element: typeof HTMLElement & { __meta?: ElementMetadata }) {
-  if (!customElements.get(name)) {
-    customElements.define(name, element);
+  const registry = getRegistry();
+  if (!registry.get(name)) {
+    registry.define(name, element);
+
+    // When using a scoped registry, wire it into LitElement's shadowRootOptions
+    // so that child custom elements rendered inside shadow roots are resolved correctly
+    if (registry !== customElements && 'shadowRootOptions' in element) {
+      (element as any).shadowRootOptions = { ...(element as any).shadowRootOptions, customElementRegistry: registry };
+    }
+
     const meta = { name, version: '0.0.0' };
     element.__meta = meta;
     GlobalStateService.dispatch('defineElement', { elementRegistry: [meta] });

--- a/projects/components/src/scoped-registry.spec.ts
+++ b/projects/components/src/scoped-registry.spec.ts
@@ -44,11 +44,9 @@ describe('createBlueprintRegistry', () => {
       return;
     }
 
-    let definedInRegistry: CustomElementRegistry;
     const registry = await createBlueprintRegistry([
       async () => {
-        const { defineElement, getRegistry: getReg } = await import('./internals/utils/define.js');
-        definedInRegistry = getReg();
+        const { defineElement } = await import('./internals/utils/define.js');
         class TestScopedCreate extends HTMLElement {}
         defineElement('test-scoped-create', TestScopedCreate);
       }

--- a/projects/components/src/scoped-registry.spec.ts
+++ b/projects/components/src/scoped-registry.spec.ts
@@ -1,0 +1,70 @@
+import { createBlueprintRegistry, getRegistry } from './scoped-registry.js';
+
+describe('createBlueprintRegistry', () => {
+  it('should return the global registry when CustomElementRegistry constructor is unavailable', async () => {
+    // If the browser supports it, this test will validate the scoped path instead
+    const registry = await createBlueprintRegistry([]);
+    expect(registry).toBeDefined();
+  });
+
+  it('should restore the previous registry after loading', async () => {
+    const before = getRegistry();
+    await createBlueprintRegistry([]);
+    expect(getRegistry()).toBe(before);
+  });
+
+  it('should restore the previous registry even if a loader throws', async () => {
+    const before = getRegistry();
+    try {
+      await createBlueprintRegistry([() => Promise.reject(new Error('fail'))]);
+    } catch {
+      // expected
+    }
+    expect(getRegistry()).toBe(before);
+  });
+
+  it('should execute all provided loaders', async () => {
+    const calls: number[] = [];
+    await createBlueprintRegistry([
+      () => {
+        calls.push(1);
+        return Promise.resolve();
+      },
+      () => {
+        calls.push(2);
+        return Promise.resolve();
+      }
+    ]);
+    expect(calls).toEqual([1, 2]);
+  });
+
+  it('should return a scoped registry with defined elements when supported', async () => {
+    if (!supportsConstructableRegistry()) {
+      pending('CustomElementRegistry constructor not available');
+      return;
+    }
+
+    let definedInRegistry: CustomElementRegistry;
+    const registry = await createBlueprintRegistry([
+      async () => {
+        const { defineElement, getRegistry: getReg } = await import('./internals/utils/define.js');
+        definedInRegistry = getReg();
+        class TestScopedCreate extends HTMLElement {}
+        defineElement('test-scoped-create', TestScopedCreate);
+      }
+    ]);
+
+    expect(registry).not.toBe(customElements);
+    expect(registry.get('test-scoped-create')).toBeDefined();
+    expect(customElements.get('test-scoped-create')).toBeUndefined();
+  });
+});
+
+function supportsConstructableRegistry(): boolean {
+  try {
+    new CustomElementRegistry();
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/projects/components/src/scoped-registry.ts
+++ b/projects/components/src/scoped-registry.ts
@@ -26,7 +26,7 @@ export { setRegistry, getRegistry } from './internals/utils/define.js';
  * shadow.innerHTML = '<bp-button>Click me</bp-button>';
  * ```
  */
-export async function createBlueprintRegistry(loaders: Array<() => Promise<unknown>>): Promise<CustomElementRegistry> {
+export async function createBlueprintRegistry(loaders: (() => Promise<unknown>)[]): Promise<CustomElementRegistry> {
   // Feature detection: fall back to global registry when constructor is unavailable
   let registry: CustomElementRegistry;
   try {

--- a/projects/components/src/scoped-registry.ts
+++ b/projects/components/src/scoped-registry.ts
@@ -1,0 +1,47 @@
+import { setRegistry, getRegistry } from './internals/utils/define.js';
+
+export { setRegistry, getRegistry } from './internals/utils/define.js';
+
+/**
+ * Creates a new scoped `CustomElementRegistry` and registers Blueprint UI
+ * components into it by executing the provided loader functions.
+ *
+ * The returned registry can be passed to `attachShadow({ customElementRegistry })`
+ * so that Blueprint UI elements are resolved within that shadow root without
+ * polluting the global `customElements` registry.
+ *
+ * Falls back to the global registry when `CustomElementRegistry` is not
+ * constructible (Firefox < 135 and older browsers).
+ *
+ * @example
+ * ```ts
+ * import { createBlueprintRegistry } from '@blueprintui/components/scoped-registry';
+ *
+ * const registry = await createBlueprintRegistry([
+ *   () => import('@blueprintui/components/include/button.js'),
+ *   () => import('@blueprintui/components/include/input.js'),
+ * ]);
+ *
+ * const shadow = host.attachShadow({ mode: 'open', customElementRegistry: registry });
+ * shadow.innerHTML = '<bp-button>Click me</bp-button>';
+ * ```
+ */
+export async function createBlueprintRegistry(loaders: Array<() => Promise<unknown>>): Promise<CustomElementRegistry> {
+  // Feature detection: fall back to global registry when constructor is unavailable
+  let registry: CustomElementRegistry;
+  try {
+    registry = new CustomElementRegistry();
+  } catch {
+    await Promise.all(loaders.map(fn => fn()));
+    return customElements;
+  }
+
+  const previous = getRegistry();
+  setRegistry(registry);
+  try {
+    await Promise.all(loaders.map(fn => fn()));
+  } finally {
+    setRegistry(previous);
+  }
+  return registry;
+}


### PR DESCRIPTION
Add opt-in scoped registry system that lets consumers register Blueprint
UI components into a scoped CustomElementRegistry instead of the global
one, enabling multiple versions or isolated instances to coexist.

- Update defineElement to use an active registry (defaults to global)
- Auto-wire scoped registry into LitElement shadowRootOptions for
  components that render child custom elements internally
- Add createBlueprintRegistry() async helper with graceful fallback
  to global registry when constructor is unavailable
- Add TypeScript type augmentations for ShadowRootInit
- Export new public API via @blueprintui/components/scoped-registry

https://claude.ai/code/session_01JEYzLbW6NRjQxi29Y8rHa8